### PR TITLE
Ignore errors if unmount fails

### DIFF
--- a/src/fwup.c
+++ b/src/fwup.c
@@ -239,8 +239,9 @@ int main(int argc, char **argv)
             }
         }
 
-        // unmount everything using the device to avoid corrupting partitions
-        mmc_umount_all(mmc_device);
+        // attempt to unmount everything using the device to avoid corrupting partitions
+        mmc_attempt_umount_all(mmc_device);
+
         if (fwup_apply(input_firmware,
                        task,
                        mmc_device,

--- a/src/mmc.c
+++ b/src/mmc.c
@@ -180,7 +180,7 @@ static char *unescape_string(const char *input)
     return result;
 }
 
-void mmc_umount_all(const char *mmc_device)
+void mmc_attempt_umount_all(const char *mmc_device)
 {
     FILE *fp = fopen("/proc/mounts", "r");
     if (!fp)
@@ -220,11 +220,11 @@ void mmc_umount_all(const char *mmc_device)
             sprintf(cmdline, "/bin/umount %s", todo[i]);
             int rc = system(cmdline);
             if (rc != 0)
-                err(EXIT_FAILURE, "%s", cmdline);
+                warnx("%s", cmdline); // don't exit if unmount unsuccessful
         } else {
             // No /etc/mtab, so call the kernel directly.
             if (umount(todo[i]) < 0)
-                err(EXIT_FAILURE, "umount %s", todo[i]);
+                warnx("umount %s", todo[i]); // don't exit if unmount unsuccessful
         }
     }
 

--- a/src/mmc.h
+++ b/src/mmc.h
@@ -23,6 +23,6 @@
 void mmc_pretty_size(off_t amount, char *out);
 off_t mmc_device_size(const char *devpath);
 char *mmc_find_device();
-void mmc_umount_all(const char *mmc_path);
+void mmc_attempt_umount_all(const char *mmc_path);
 
 #endif // MMC_H


### PR DESCRIPTION
If fwup cannot unmount a partition it will still display the umount error message, but will no longer exit.