### PR TITLE
Adding more detail to error message

### DIFF
--- a/src/fatfs.c
+++ b/src/fatfs.c
@@ -267,9 +267,11 @@ int fatfs_pwrite(struct fat_cache *fc,const char *filename, int offset, const ch
 
     UINT bw;
     CHECK("fat_write can't write", filename, f_write(&fil_, buffer, size, &bw));
-    if (size != bw)
-        ERR_RETURN("Error writing file to FAT");
 
+    if (size != bw) {
+      ERR_RETURN("Error writing file to FAT: %s, expected %ld bytes written, got %d (maybe the disk is full?)", filename, size, bw);
+    }
+    
     return 0;
 }
 


### PR DESCRIPTION
I ended up with a kernel that was too large for the fat partition in my fwup.conf. The error message just said "Error writing file to FAT" and it took a fair bit of debugging to figure out what was actually happening (because I'm a noob :D). This adds a bit of useful information to the error message. My big kernel now gives the error: "fwup: Error writing file to FAT: zImage, expected 96590 bytes written, got 79944 (maybe the disk is full?)"

