### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ On OSX:
 
 On Ubuntu:
 
-    # libconfuse 2.8 is required but not available in apt
+    # The version of libconfuse available in apt is too old
     curl -L https://github.com/martinh/libconfuse/releases/download/v2.8/confuse-2.8.tar.gz | tar -xz -C /tmp
     pushd /tmp/confuse-2.8
     ./configure && make && sudo make install


### PR DESCRIPTION
Change comment on installing libconfuse in Ubuntu to acknowledge libconfuse is available in apt, but is the wrong version, bringing it in line with the CentOS comments regarding libconfuse.