### PR TITLE
Add missing <sys/types.h> includes

### DIFF
--- a/src/cfgfile.h
+++ b/src/cfgfile.h
@@ -17,6 +17,7 @@
 #ifndef CFGFILE_H
 #define CFGFILE_H
 
+#include <sys/types.h>
 #include <confuse.h>
 
 struct archive;

--- a/src/mmc.h
+++ b/src/mmc.h
@@ -20,6 +20,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 #define MMC_DEVICE_PATH_LEN 32
 

--- a/src/util.h
+++ b/src/util.h
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 struct tm;
 


### PR DESCRIPTION
<sys/types.h> is needed for the definition of off_t, otherwise building
with uClibc fails with:

In file included from cfgfile.c:17:0:
cfgfile.h:25:87: error: unknown type name ‘off_t’
 int archive_read_all_data(struct archive *a, struct archive_entry *ae, char **buffer, off_t max_size, off_t *size_read);
                                                                                       ^
cfgfile.h:25:103: error: unknown type name ‘off_t’
 int archive_read_all_data(struct archive *a, struct archive_entry *ae, char **buffer, off_t max_size, off_t *size_read);

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>