### PR TITLE
m4: add directory needed for autoreconf to succeed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ tests/15M.bin
 /config.sub
 /libtool
 /ltmain.sh
-/m4
 src/fwup.1
 *.rpm
 *.deb

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-mkdir -p m4 # silence autoreconf warning
 autoreconf --install


### PR DESCRIPTION
Using the autogen.sh script should not be mandatory, using autoreconf
directly should also be possible, and is actually done by numerous
embedded Linux build systems.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>