### PR TITLE
Enumerate PhysicalDrives instead of LogicalVolumes on Windows

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -210,6 +210,10 @@ int archive_filename_to_resource(const char *name, char *result, size_t maxlengt
  */
 bool will_be_regular_file(const char *path)
 {
+#ifdef _WIN32
+    if (strncmp(path, "\\\\.\\", 4) == 0)
+        return 0;
+#endif
     struct stat st;
     int rc = stat(path, &st);
     return (rc == 0 && st.st_mode & S_IFREG) ||


### PR DESCRIPTION
In Windows, a LogicalVolume is a partition or collection of disks (e.g. a RAID group) that has a drive letter. I think what fwup would want to write to is the raw disk itself, which is a PhysicalDrive.

These are conveniently numbered from 1 to N as they are enumerated by the system. Unfortunately, there's not a reliable API to tell you which ones exist. They can disappear (e.g. by unplugging a USB device), leaving a gap in the sequence, as the higher-numbered PhysicalDrives are not re-numbered.

This implementation simply walks across the numbered drives until it finds 5 in a row that are invalid (do not exist). This eliminates the need to assume there won't be more than N drives and checking that many, and would only cause trouble if someone plugged in more than 5 card readers and then un-plugged all but the last one.