### PR TITLE
Add zip to common dependencies

### DIFF
--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -17,7 +17,7 @@ Before building, make sure that your system has some basic packages installed.
 At least the following are required for building and running the regression
 tests:
 
-    sudo apt-get install build-essential autoconf pkg-config libtool mtools unzip
+    sudo apt-get install build-essential autoconf pkg-config libtool mtools unzip zip
 
 ## Static build
 


### PR DESCRIPTION
Without zip installed the following tests will fail:
* 015_fat_bad_sha2.test
* 016_raw_bad_sha2.test
* 047_unknown_apply_succeeds.test