### PR TITLE
fix warning to be WN

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -99,7 +99,7 @@ char* strptime(const char *buf, const char *fmt, struct tm *tm);
 
 #define FRAMING_TYPE_SUCCESS  "OK"
 #define FRAMING_TYPE_ERROR    "ER"
-#define FRAMING_TYPE_WARNING  "WA"
+#define FRAMING_TYPE_WARNING  "WN"
 #define FRAMING_TYPE_PROGRESS "PR"
 
 // Send output to the terminal based on the framing options


### PR DESCRIPTION
Fixes the prefix so that it patches the docs. I think WN is better than WA. Thoughts?