### PR TITLE
Fix uclibc build

### DIFF
--- a/src/sparse_file.h
+++ b/src/sparse_file.h
@@ -18,6 +18,7 @@
 #define SPARSE_FILE_H
 
 #include <confuse.h>
+#include <sys/types.h>
 
 struct sparse_file_map
 {


### PR DESCRIPTION
Without sys/types.h the build breaks with errors like this:

parse_file.h:28:5: error: unknown type name ‘off_t’
     off_t *map;
     ^