### PR TITLE
Add missing build_deps.sh step to docs for static build on Linux

### DIFF
--- a/docs/build_linux.md
+++ b/docs/build_linux.md
@@ -26,6 +26,7 @@ is a fairly typical build process. Modify the `./configure` line if necessary to
 change the installation location.
 
     ./scripts/download_deps.sh
+    ./scripts/build_deps.sh
     ./autogen.sh    # only necessary if building from a git source tree
     PKG_CONFIG_PATH=/home/fhunleth/fwup/build/host/deps/usr/lib/pkgconfig ./configure --enable-shared=no
     make


### PR DESCRIPTION
I had to call `./scripts/build_deps.sh` before the `./configure` step was satisfied.