### PR TITLE
Base64 encode signing keys and support passing keys in via commandline

### DIFF
--- a/3rdparty/base64.c
+++ b/3rdparty/base64.c
@@ -1,0 +1,193 @@
+// This file contains private base64 utilities from libsodium.
+// See https://raw.githubusercontent.com/jedisct1/libsodium/c229663acf6083867b8df35aeb8647e6d4db1270/src/libsodium/crypto_pwhash/argon2/argon2-encoding.c
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Example code for a decoder and encoder of "hash strings", with Argon2
+ * parameters.
+ *
+ * This code comprises three sections:
+ *
+ *   -- The first section contains generic Base64 encoding and decoding
+ *   functions. It is conceptually applicable to any hash function
+ *   implementation that uses Base64 to encode and decode parameters,
+ *   salts and outputs. It could be made into a library, provided that
+ *   the relevant functions are made public (non-static) and be given
+ *   reasonable names to avoid collisions with other functions.
+ *
+ *   -- The second section is specific to Argon2. It encodes and decodes
+ *   the parameters, salts and outputs. It does not compute the hash
+ *   itself.
+ *
+ * The code was originally written by Thomas Pornin <pornin@bolet.org>,
+ * to whom comments and remarks may be sent. It is released under what
+ * should amount to Public Domain or its closest equivalent; the
+ * following mantra is supposed to incarnate that fact with all the
+ * proper legal rituals:
+ *
+ * ---------------------------------------------------------------------
+ * This file is provided under the terms of Creative Commons CC0 1.0
+ * Public Domain Dedication. To the extent possible under law, the
+ * author (Thomas Pornin) has waived all copyright and related or
+ * neighboring rights to this file. This work is published from: Canada.
+ * ---------------------------------------------------------------------
+ *
+ * Copyright (c) 2015 Thomas Pornin
+ */
+
+/* ==================================================================== */
+/*
+ * Common code; could be shared between different hash functions.
+ *
+ * Note: the Base64 functions below assume that uppercase letters (resp.
+ * lowercase letters) have consecutive numerical codes, that fit on 8
+ * bits. All modern systems use ASCII-compatible charsets, where these
+ * properties are true. If you are stuck with a dinosaur of a system
+ * that still defaults to EBCDIC then you already have much bigger
+ * interoperability issues to deal with.
+ */
+
+/*
+ * Some macros for constant-time comparisons. These work over values in
+ * the 0..255 range. Returned value is 0x00 on "false", 0xFF on "true".
+ */
+#define EQ(x, y) \
+    ((((0U - ((unsigned) (x) ^ (unsigned) (y))) >> 8) & 0xFF) ^ 0xFF)
+#define GT(x, y) ((((unsigned) (y) - (unsigned) (x)) >> 8) & 0xFF)
+#define GE(x, y) (GT(y, x) ^ 0xFF)
+#define LT(x, y) GT(y, x)
+#define LE(x, y) GE(y, x)
+
+/*
+ * Convert value x (0..63) to corresponding Base64 character.
+ */
+static int
+b64_byte_to_char(unsigned x)
+{
+    return (LT(x, 26) & (x + 'A')) |
+           (GE(x, 26) & LT(x, 52) & (x + ('a' - 26))) |
+           (GE(x, 52) & LT(x, 62) & (x + ('0' - 52))) | (EQ(x, 62) & '+') |
+           (EQ(x, 63) & '/');
+}
+
+/*
+ * Convert character c to the corresponding 6-bit value. If character c
+ * is not a Base64 character, then 0xFF (255) is returned.
+ */
+static unsigned
+b64_char_to_byte(int c)
+{
+    unsigned x;
+
+    x = (GE(c, 'A') & LE(c, 'Z') & (c - 'A')) |
+        (GE(c, 'a') & LE(c, 'z') & (c - ('a' - 26))) |
+        (GE(c, '0') & LE(c, '9') & (c - ('0' - 52))) | (EQ(c, '+') & 62) |
+        (EQ(c, '/') & 63);
+    return x | (EQ(x, 0) & (EQ(c, 'A') ^ 0xFF));
+}
+
+/*
+ * Convert some bytes to Base64. 'dst_len' is the length (in characters)
+ * of the output buffer 'dst'; if that buffer is not large enough to
+ * receive the result (including the terminating 0), then (size_t)-1
+ * is returned. Otherwise, the zero-terminated Base64 string is written
+ * in the buffer, and the output length (counted WITHOUT the terminating
+ * zero) is returned.
+ */
+size_t
+to_base64(char *dst, size_t dst_len, const void *src, size_t src_len)
+{
+    size_t               olen;
+    const unsigned char *buf;
+    unsigned             acc, acc_len;
+
+    olen = (src_len / 3) << 2;
+    switch (src_len % 3) {
+    case 2:
+        olen++;
+    /* fall through */
+    case 1:
+        olen += 2;
+        break;
+    }
+    if (dst_len <= olen) {
+        return (size_t) -1;
+    }
+    acc     = 0;
+    acc_len = 0;
+    buf     = (const unsigned char *) src;
+    while (src_len-- > 0) {
+        acc = (acc << 8) + (*buf++);
+        acc_len += 8;
+        while (acc_len >= 6) {
+            acc_len -= 6;
+            *dst++ = (char) b64_byte_to_char((acc >> acc_len) & 0x3F);
+        }
+    }
+    if (acc_len > 0) {
+        *dst++ = (char) b64_byte_to_char((acc << (6 - acc_len)) & 0x3F);
+    }
+    *dst++ = 0;
+    return olen;
+}
+
+/*
+ * Decode Base64 chars into bytes. The '*dst_len' value must initially
+ * contain the length of the output buffer '*dst'; when the decoding
+ * ends, the actual number of decoded bytes is written back in
+ * '*dst_len'.
+ *
+ * Decoding stops when a non-Base64 character is encountered, or when
+ * the output buffer capacity is exceeded. If an error occurred (output
+ * buffer is too small, invalid last characters leading to unprocessed
+ * buffered bits), then NULL is returned; otherwise, the returned value
+ * points to the first non-Base64 character in the source stream, which
+ * may be the terminating zero.
+ */
+const char *
+from_base64(void *dst, size_t *dst_len, const char *src)
+{
+    size_t         len;
+    unsigned char *buf;
+    unsigned       acc, acc_len;
+
+    buf     = (unsigned char *) dst;
+    len     = 0;
+    acc     = 0;
+    acc_len = 0;
+    for (;;) {
+        unsigned d;
+
+        d = b64_char_to_byte(*src);
+        if (d == 0xFF) {
+            break;
+        }
+        src++;
+        acc = (acc << 6) + d;
+        acc_len += 6;
+        if (acc_len >= 8) {
+            acc_len -= 8;
+            if ((len++) >= *dst_len) {
+                return NULL;
+            }
+            *buf++ = (acc >> acc_len) & 0xFF;
+        }
+    }
+
+    /*
+     * If the input length is equal to 1 modulo 4 (which is
+     * invalid), then there will remain 6 unprocessed bits;
+     * otherwise, only 0, 2 or 4 bits are buffered. The buffered
+     * bits must also all be zero.
+     */
+    if (acc_len > 4 || (acc & ((1U << acc_len) - 1)) != 0) {
+        return NULL;
+    }
+    *dst_len = len;
+    return src;
+}
+

--- a/3rdparty/base64.h
+++ b/3rdparty/base64.h
@@ -1,0 +1,26 @@
+#ifndef BASE64_H
+#define BASE64_H
+
+static inline size_t base64_raw_to_encoded_count(size_t len)
+{
+    // Base64 converts 3 bytes to 4 encoded characters
+    size_t groups = (len + 2) / 3;
+    return groups * 4;
+}
+
+static inline size_t base64_raw_to_unpadded_count(size_t len)
+{
+    // Base64 converts 3 bytes to 4 encoded characters
+    size_t groups = len / 3;
+    size_t normal_bytes = groups * 3;
+    size_t extras = 0;
+    if (normal_bytes != len)
+        extras = len - normal_bytes + 1;
+
+    return groups * 4 + extras;
+}
+
+size_t to_base64(char *dst, size_t dst_len, const void *src, size_t src_len);
+const char *from_base64(void *dst, size_t *dst_len, const char *src);
+
+#endif // BASE64_H

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v0.15.4-dev
 
+  * New features
+    * Changed signing keys to be base64 encoded so that they'd be easier to bake
+      into firmware and pass in environment variables on CI systems. The
+      previous raw binary format still works and will remain supported.
+    * Added commandline parameters for passing public and private keys via
+      commandline arguments. Along with the base64 change, this cleans up CI
+      build scripts.
+
   * Bug fixes/Improvements
     * Fix lseek seek_end issue on Mac when working with SDCards. This fixed an
       issue where upgrade tasks didn't work on Macs. Not a common issue, but

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ Options:
   -a, --apply   Apply the firmware update
   -c, --create  Create the firmware update
   -d <file> Device file for the memory card
-  -D, --detect List attached SDCards or MMC devices
+  -D, --detect List attached SDCards or MMC devices and their sizes
   -E, --eject Eject removeable media after successfully writing firmware.
-  --enable-trim Enable use of the hardware TRIM command
   --no-eject Do not eject media after writing firmware
+  --enable-trim Enable use of the hardware TRIM command
   -f <fwupdate.conf> Specify the firmware update configuration file
   -F, --framing Apply framing on stdin/stdout
   -g, --gen-keys Generate firmware signing keys (fwup-key.pub and fwup-key.priv)
@@ -134,8 +134,10 @@ Options:
   -n   Report numeric progress
   -o <output.fw> Specify the output file when creating an update (Use - for stdout)
   -p <keyfile> A public key file for verifying firmware updates
+  --private-key <key> A private key for signing firmware updates
   --progress-low <number> When displaying progress, this is the lowest number (normally 0 for 0%)
   --progress-high <number> When displaying progress, this is the highest number (normally 100 for 100%)
+  --public-key <key> A public key for verifying firmware updates
   -q, --quiet   Quiet
   -s <keyfile> A private key file for signing firmware updates
   -S, --sign Sign an existing firmware file (specify -i and -o)
@@ -150,7 +152,7 @@ Options:
   -y   Accept automatically found memory card when applying a firmware update
   -z   Print the memory card that would be automatically detected and exit
   -1   Fast compression (for create)
-  -9   Best compression (for create)
+  -9   Best compression (default)
 
 Examples:
 

--- a/fwup.pro
+++ b/fwup.pro
@@ -44,7 +44,8 @@ SOURCES += \
     src/mmc_bsd.c \
     src/resources.c \
     src/block_cache.c \
-    src/pad_to_block_writer.c
+    src/pad_to_block_writer.c \
+    3rdparty/base64.c
 
 osx {
     INCLUDEPATH += /usr/local/include /usr/local/opt/libarchive/include
@@ -96,7 +97,8 @@ HEADERS += \
     src/resources.h \
     src/block_cache.h \
     src/fatfs.h \
-    src/pad_to_block_writer.h
+    src/pad_to_block_writer.h \
+    3rdparty/base64.h
 
 OTHER_FILES += \
     fwupdate.conf \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,6 +58,8 @@ fwup_SOURCES=\
 	sparse_file.h \
 	uboot_env.h \
 	util.h \
+	../3rdparty/base64.c \
+	../3rdparty/base64.h \
 	../3rdparty/fatfs/src/diskio.h \
 	../3rdparty/fatfs/src/integer.h \
 	../3rdparty/fatfs/src/ff.c \

--- a/tests/021_create_keys.test
+++ b/tests/021_create_keys.test
@@ -10,11 +10,26 @@ cd $WORK
 $FWUP_CREATE -g
 cd -
 
-if [ `wc -c $WORK/fwup-key.pub | awk '{print $1}'` -ne 32 ]; then
-    echo "fwup-key.pub isn't 32 bytes"
+# Check that the keys are the expected base64 length
+if [ `wc -c $WORK/fwup-key.pub | awk '{print $1}'` -ne 44 ]; then
+    echo "fwup-key.pub isn't 44 bytes"
     exit 1
 fi
-if [ `wc -c $WORK/fwup-key.priv | awk '{print $1}'` -ne 64 ]; then
-    echo "fwup-key.priv isn't 64 bytes"
+if [ `wc -c $WORK/fwup-key.priv | awk '{print $1}'` -ne 88 ]; then
+    echo "fwup-key.priv isn't 88 bytes"
+    exit 1
+fi
+
+# Check that the keys base64 decode to the right length
+# base64 will fail if the encoding messed up somehow.
+base64_decode < $WORK/fwup-key.pub > $WORK/fwup-key.pub.raw
+base64_decode < $WORK/fwup-key.priv > $WORK/fwup-key.priv.raw
+
+if [ `wc -c $WORK/fwup-key.pub.raw | awk '{print $1}'` -ne 32 ]; then
+    echo "base64 -d fwup-key.pub didn't produce 32 bytes"
+    exit 1
+fi
+if [ `wc -c $WORK/fwup-key.priv.raw | awk '{print $1}'` -ne 64 ]; then
+    echo "base64 -d fwup-key.priv didn't produce 64 bytes"
     exit 1
 fi

--- a/tests/131_raw_key.test
+++ b/tests/131_raw_key.test
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+#
+# Test that signing firmware does the expected thing using
+# raw (non base64-encoded) keys. This ensures that fwup users
+# using keys created by older versions of the software still
+# work.
+#
+
+. ./common.sh
+
+cat >$CONFIG <<EOF
+file-resource TEST {
+	host-path = "${TESTFILE_1K}"
+}
+
+task complete {
+	on-resource TEST { raw_write(0) }
+}
+EOF
+
+cat >$EXPECTED_META_CONF <<EOF
+file-resource "TEST" {
+  length=1024
+  blake2b-256="b25c2dfe31707f5572d9a3670d0dcfe5d59ccb010e6aba3b81aad133eb5e378b"
+}
+task "complete" {
+  on-resource "TEST" {
+    funlist = {"2", "raw_write", "0"}
+  }
+}
+EOF
+
+# Create new keys and their raw (old style) versions and
+# unpadded base64 versions.
+cd $WORK
+$FWUP_CREATE -g
+base64_decode < fwup-key.priv > fwup-key.priv.raw
+base64_decode < fwup-key.pub > fwup-key.pub.raw
+dd if=fwup-key.pub of=fwup-key.pub.unpadded bs=1 count=43
+dd if=fwup-key.priv of=fwup-key.priv.unpadded bs=1 count=86
+cd -
+
+# Sign the firmware
+$FWUP_CREATE -s $WORK/fwup-key.priv.raw -c -f $CONFIG -o $FWFILE
+
+# Check that the zip file was created as expected
+check_meta_conf
+
+# Check that applying the firmware without checking signatures works
+$FWUP_APPLY -q -a -d $IMGFILE -i $FWFILE -t complete
+
+# Check that verifying the firmware without checking signatures works
+$FWUP_VERIFY -V -i $FWFILE
+
+# Check that applying the firmware with checking signatures works
+$FWUP_APPLY -q -p $WORK/fwup-key.pub.raw -a -d $IMGFILE -i $FWFILE -t complete
+
+# Check that using the base64-encoded key still works as well.
+$FWUP_APPLY -q -p $WORK/fwup-key.pub -a -d $IMGFILE -i $FWFILE -t complete
+
+# While we're at it, check that an unpadded key works
+$FWUP_APPLY -q -p $WORK/fwup-key.pub.unpadded -a -d $IMGFILE -i $FWFILE -t complete
+
+# Check that verifying the firmware with checking signatures works
+$FWUP_VERIFY -V -p $WORK/fwup-key.pub.raw -i $FWFILE
+
+# Check that using the base64-encoded key still works as well.
+$FWUP_VERIFY -V -p $WORK/fwup-key.pub -i $FWFILE
+
+$FWUP_VERIFY -V -p $WORK/fwup-key.pub.unpadded -i $FWFILE

--- a/tests/132_key_as_param.test
+++ b/tests/132_key_as_param.test
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+#
+# Test that it's possible to pass keys around as commandline parameters
+#
+
+. ./common.sh
+
+cat >$CONFIG <<EOF
+file-resource TEST {
+	host-path = "${TESTFILE_1K}"
+}
+
+task complete {
+	on-resource TEST { raw_write(0) }
+}
+EOF
+
+cat >$EXPECTED_META_CONF <<EOF
+file-resource "TEST" {
+  length=1024
+  blake2b-256="b25c2dfe31707f5572d9a3670d0dcfe5d59ccb010e6aba3b81aad133eb5e378b"
+}
+task "complete" {
+  on-resource "TEST" {
+    funlist = {"2", "raw_write", "0"}
+  }
+}
+EOF
+
+# Create new keys
+cd $WORK
+$FWUP_CREATE -g
+cd -
+
+PUBLIC_KEY=$(cat $WORK/fwup-key.pub)
+PRIVATE_KEY=$(cat $WORK/fwup-key.priv)
+
+# Sign the firmware
+$FWUP_CREATE --private-key $PRIVATE_KEY -c -f $CONFIG -o $FWFILE
+
+# Check that the zip file was created as expected
+check_meta_conf
+
+# Check that applying the firmware with checking signatures works
+$FWUP_APPLY -q --public-key $PUBLIC_KEY -a -d $IMGFILE -i $FWFILE -t complete
+
+# Check that verifying the firmware with checking signatures works
+$FWUP_VERIFY -V --public-key $PUBLIC_KEY -i $FWFILE

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -143,6 +143,7 @@ TESTS = 001_simple_fw.test \
 	127_extra_metadata.test \
 	128_blank_offset.test \
 	129_mbr_overflow.test \
-	130_media_sizes.test
+	130_media_sizes.test \
+	131_raw_key.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -144,6 +144,7 @@ TESTS = 001_simple_fw.test \
 	128_blank_offset.test \
 	129_mbr_overflow.test \
 	130_media_sizes.test \
-	131_raw_key.test
+	131_raw_key.test \
+	132_key_as_param.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
This add support for passing signing keys around as text (base64-encoded) so that keys may more easily be stored as strings in code and environment variables on CI servers. This also adds commandline argments (`--public-key` and `--private-key`). This change removes the need to create temporary key files. Obviously, the standard care still needs to be taken when passing private keys in using this mechanism so that they don't appear in publicly viewable logs. The expected use for this is to sign firmware on CI servers where the private key is stored in an environment variable. 