### PR TITLE
Disable tests due to cross-platform-isms

### DIFF
--- a/docs/ubi_example/fwup.conf
+++ b/docs/ubi_example/fwup.conf
@@ -63,8 +63,9 @@ file-resource ubi.ini {
 	host-path = "ubi.ini"
 }
 file-resource rootfs.img {
-  host-path = ${ROOTFS}
+  host-path = "${ROOTFS}"
 }
+file-resource-size(ROOTFS_SIZE,"${ROOTFS}")
 task complete {
   on-init {
     execute("mkdir _tmp")
@@ -115,7 +116,7 @@ task upgrade.a {
   }
   # Update NAND
   on-resource rootfs.img {
-    pipe_write("ubiupdatevol /dev/ubi0_0 -")
+    pipe_write("ubiupdatevol /dev/ubi0_0 -s ${ROOTFS_SIZE} -")
   }
 
   on-finish {
@@ -135,7 +136,7 @@ task upgrade.b {
   }
   # Update NAND
   on-resource rootfs.img {
-    pipe_write("ubiupdatevol /dev/ubi0_1 -")
+    pipe_write("ubiupdatevol /dev/ubi0_1 -s ${ROOTFS_SIZE} -")
   }
 
   on-finish {

--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -196,6 +196,23 @@ static int cb_define_eval_bang(cfg_t *cfg, cfg_opt_t *opt, int argc, const char 
     return define_helper(cfg, argv[0], result_str, true);
 }
 
+static int cb_file_resource_size(cfg_t *cfg, cfg_opt_t *opt, int argc, const char **argv)
+{
+    struct stat st; 
+
+    // Overriding version of define_eval
+    if (check_param_count(cfg, opt, argc, 2) < 0)
+        return -1;
+
+    if (stat(argv[1], &st) != 0)
+        return -1;
+
+
+    char result_str[24]; // Large enough to hold 64 bit int
+    snprintf(result_str,24,"%d",st.st_size);
+
+    return define_helper(cfg, argv[0], result_str, true);
+}
 // libconfuse calls the validators every time an item is added
 // to a section. The idiom is to validate the most recently
 // added item each time. This one is also the last one in the list.
@@ -430,6 +447,7 @@ cfg_opt_t opts[] = {
     CFG_FUNC("define-eval", cb_define_eval),
     CFG_FUNC("define-eval!", cb_define_eval_bang),
     CFG_SEC("file-resource", file_resource_opts, CFGF_MULTI | CFGF_TITLE | CFGF_NO_TITLE_DUPES),
+    CFG_FUNC("file-resource-size", cb_file_resource_size),
     CFG_SEC("mbr", mbr_opts, CFGF_MULTI | CFGF_TITLE | CFGF_NO_TITLE_DUPES),
     CFG_SEC("task", task_opts, CFGF_MULTI | CFGF_TITLE | CFGF_NO_TITLE_DUPES),
     CFG_SEC("uboot-environment", uboot_environment_opts, CFGF_MULTI | CFGF_TITLE | CFGF_NO_TITLE_DUPES),

--- a/tests/134_pipe_write_file.test
+++ b/tests/134_pipe_write_file.test
@@ -9,9 +9,10 @@
 
 OUTFILE=$WORK/output1k
 
-
+# Handle Crossplatform-isms
 case $HOST_OS in
     Windows)
+        # Not many Windows executables read from STDIN
         exit 0
         ;;
     *)

--- a/tests/134_pipe_write_file.test
+++ b/tests/134_pipe_write_file.test
@@ -12,7 +12,8 @@ OUTFILE=$WORK/output1k
 # Handle Crossplatform-isms
 case $HOST_OS in
     Windows)
-        # Not many Windows executables read from STDIN
+        # This test needs a Windows executable that reads from STDIN.  
+        # No sutable executables are currently on Travis CI Image
         exit 0
         ;;
     *)

--- a/tests/134_pipe_write_file.test
+++ b/tests/134_pipe_write_file.test
@@ -9,6 +9,15 @@
 
 OUTFILE=$WORK/output1k
 
+
+case $HOST_OS in
+    Windows)
+        exit 0
+        ;;
+    *)
+        ;;
+esac
+
 cat >$CONFIG <<EOF
 file-resource TEST {
 	host-path = "${TESTFILE_1K}"

--- a/tests/135_execute.test
+++ b/tests/135_execute.test
@@ -10,6 +10,15 @@
 export OUTFILE=$WORK/output.txt
 export LOCAL_FILE=$WORK/somefile.txt
 
+case $HOST_OS in
+    Windows)
+        # Has its own exes
+        exit 0
+        ;;
+    *)
+        ;;
+esac
+
 cat >$LOCAL_FILE <<EOF
 This is a test.  It is only a test
 EOF

--- a/tests/135_execute.test
+++ b/tests/135_execute.test
@@ -10,12 +10,13 @@
 export OUTFILE=$WORK/output.txt
 export LOCAL_FILE=$WORK/somefile.txt
 
+# Handle Crossplatform-isms
 case $HOST_OS in
     Windows)
-        # Has its own exes
-        exit 0
+        EXE_CMD="copy work-135_execute.test\\\\somefile.txt work-135_execute.test\\\\output.txt"
         ;;
     *)
+        EXE_CMD="dd if=${LOCAL_FILE} of=${OUTFILE}"
         ;;
 esac
 
@@ -25,7 +26,7 @@ EOF
 
 cat >$CONFIG <<EOF
 task complete {
-	on-finish { execute("dd if=${LOCAL_FILE} of=${OUTFILE}") }
+	on-finish { execute("${EXE_CMD}") }
 }
 task bad_command {
 	on-finish { execute("badcommand1234") }

--- a/tests/139_file_resource_size.test
+++ b/tests/139_file_resource_size.test
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+#
+# Test saving the size of a resource to an Variable
+#
+
+. ./common.sh
+
+export ACTUAL_SIZE_FILE=$WORK/actual_size.txt
+export EXPECTED_SIZE_FILE=$WORK/expected_size.txt
+
+cat >$EXPECTED_SIZE_FILE <<EOF
+1024 
+EOF
+
+cat >$CONFIG <<EOF
+file-resource TEST {
+    host-path = "${TESTFILE_1K}"
+}
+
+file-resource-size(FILE_SIZE,"${TESTFILE_1K}")
+
+task complete {
+	on-finish { execute("echo \${FILE_SIZE} > \${ACTUAL_SIZE_FILE}") }
+}
+EOF
+
+# Create the firmware file like normal
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Apply the firmware and verify that the local file was copied
+$FWUP_APPLY --unsafe -a -d $IMGFILE -i $FWFILE -t complete
+diff -w $EXPECTED_SIZE_FILE $ACTUAL_SIZE_FILE
+

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -151,6 +151,7 @@ TESTS = 001_simple_fw.test \
 	135_execute.test \
 	136_fat_overwrite.test \
 	137_path_write_sparse.test \
-	138_pipe_write_sparse.test
+	138_pipe_write_sparse.test \
+	139_file_resource_size.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -11,7 +11,7 @@ BASE64_DECODE=-d
 FSCK_FAT=fsck.fat
 TIMEOUT=timeout
 
-if [ -d "/mnt/c/Users" ]; then
+if [ -d "/mnt/c/Users" ] || [ "$MODE" = "windows" ]; then
     # Windows 10 bash mode
     HOST_OS=Windows
     HOST_ARCH=amd64


### PR DESCRIPTION
@fhunleth I tried in vain tonight to come up with a stock Windows command that reads from STDIN for the pipe test.

In the mean time at least this fixes the unit tests