### PR TITLE
src/mmc_linux.c: Include <sys/sysmacros.h>

### DIFF
--- a/src/mmc_linux.c
+++ b/src/mmc_linux.c
@@ -25,6 +25,7 @@
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <sys/sysmacros.h>
 
 #include <fcntl.h>
 #include <inttypes.h>


### PR DESCRIPTION
Future glibc releases won't include sysmacros implicitly anymore and will
fail with errors like:

```
fwup-mmc_linux.o: In function `mmc_is_path_at_device_offset':
mmc_linux.c:(.text+0x478): undefined reference to `minor'
mmc_linux.c:(.text+0x485): undefined reference to `major'
collect2: error: ld returned 1 exit status
```