### PR TITLE
Add potential cause to error message.

### DIFF
--- a/src/block_cache.c
+++ b/src/block_cache.c
@@ -160,7 +160,7 @@ static int read_segment(struct block_cache *bc, struct block_cache_segment *seg,
     } else {
         ssize_t bytes_read = pread(bc->fd, data, BLOCK_CACHE_SEGMENT_SIZE, seg->offset);
         if (bytes_read < 0) {
-            ERR_RETURN("unexpected error reading %d bytes at offset %" PRId64 ": %s", BLOCK_CACHE_SEGMENT_SIZE, seg->offset, strerror(errno));
+            ERR_RETURN("unexpected error reading %d bytes at offset %" PRId64 ": %s. \nTry again, but your SD card may be going bad.", BLOCK_CACHE_SEGMENT_SIZE, seg->offset, strerror(errno));
         } else if (bytes_read < BLOCK_CACHE_SEGMENT_SIZE) {
             // Didn't read enough bytes. This occurs if the destination media is
             // not a multiple of the segment size. Fill the remainder with zeros


### PR DESCRIPTION
This happened to me a couple of times already. Once, I determined the SD card was a bad one. Now, I'm getting this intermittently as I burn SD cards using the slot on my laptop, so maybe this is the root cause here. I asked @fhunleth about this error and he mentioned he has only seen it in dead sd cards. Maybe this error message can help someone experiencing the same.

Also, excuse me not knowing C. Hope this is the right place to add the message.