### PR TITLE
Fix: build error

### DIFF
--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -22,7 +22,7 @@
 #include "util.h"
 #include "archive_open.h"
 #include "eval_math.h"
-#include "3rdparty/semver.c/semver.h"
+#include "../3rdparty/semver.c/semver.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/fwup_genkeys.c
+++ b/src/fwup_genkeys.c
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <limits.h>
 
 #include "../3rdparty/base64.h"
 #include "util.h"


### PR DESCRIPTION
Fix build errors:
- Include error in src/cfgfile.c
- PATH_MAX is not defined in fwup_genkeys.c

Errors occurs when build for rpi0w by yocto