### PR TITLE
Only /bin/sh is needed for img2fwup

### DIFF
--- a/img2fwup
+++ b/img2fwup
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
 IMGFILE=$1
 FWFILE=$2
 
-if [[ -z "$IMGFILE" ]]; then
+if [ -z "$IMGFILE" ]; then
     echo "Compress an image file into a .fw archive so that it can be written to a"
     echo "MicroSD card using fwup."
     echo


### PR DESCRIPTION
Yocto found this.  We are using `/bin/bash` currently when only `/bin/sh` is really needed.