### PR TITLE
Don't rely on lseek for device size

### DIFF
--- a/src/block_cache.h
+++ b/src/block_cache.h
@@ -99,7 +99,7 @@ struct block_cache {
 #endif
 };
 
-int block_cache_init(struct block_cache *bc, int fd, bool enable_trim);
+int block_cache_init(struct block_cache *bc, int fd, off_t end_offset, bool enable_trim);
 int block_cache_trim(struct block_cache *bc, off_t offset, off_t count, bool hwtrim);
 int block_cache_trim_after(struct block_cache *bc, off_t offset, bool hwtrim);
 int block_cache_pwrite(struct block_cache *bc, const void *buf, size_t count, off_t offset, bool streamed);

--- a/src/fwup_apply.c
+++ b/src/fwup_apply.c
@@ -365,6 +365,7 @@ cleanup:
 int fwup_apply(const char *fw_filename,
                const char *task_prefix,
                int output_fd,
+               off_t end_offset,
                struct fwup_progress *progress,
                unsigned char *const*public_keys,
                bool enable_trim)
@@ -418,7 +419,7 @@ int fwup_apply(const char *fw_filename,
     // Initialize the output. Nothing should have been written before now
     // and waiting to initialize the output until now forces the point.
     fctx.output = (struct block_cache *) malloc(sizeof(struct block_cache));
-    OK_OR_CLEANUP(block_cache_init(fctx.output, output_fd, enable_trim));
+    OK_OR_CLEANUP(block_cache_init(fctx.output, output_fd, end_offset, enable_trim));
 
     // Go through all of the tasks and find a matcher
     fctx.task = find_task(&fctx, task_prefix);

--- a/src/fwup_apply.h
+++ b/src/fwup_apply.h
@@ -21,6 +21,6 @@
 
 struct fwup_progress;
 
-int fwup_apply(const char *fw_filename, const char *task, int output_fd, struct fwup_progress *progress, unsigned char *const* public_keys, bool enable_trim);
+int fwup_apply(const char *fw_filename, const char *task, int output_fd, off_t end_offset, struct fwup_progress *progress, unsigned char *const* public_keys, bool enable_trim);
 
 #endif // FWUP_APPLY_H

--- a/src/mbr.c
+++ b/src/mbr.c
@@ -194,7 +194,7 @@ static int write_osip(const struct osip_header *osip, uint8_t *output)
  * @param bootstrap optional bootstrap code (must be 440 bytes or NULL if none)
  * @param osip optional OSIP header (NULL if none)
  * @param signature
- * @param num_blocks the total number of blocks in the storage or 0
+ * @param num_blocks the total number of blocks in the storage or 0 if unknown
  * @param output the output location
  * @return 0 if success
  */
@@ -372,6 +372,7 @@ static int mbr_cfg_to_osip(cfg_t *cfg, struct osip_header *osip)
 
     return 0;
 }
+
 int mbr_verify_cfg(cfg_t *cfg)
 {
     int found_partitions = 0;
@@ -398,7 +399,14 @@ int mbr_verify_cfg(cfg_t *cfg)
     return mbr_verify(partitions);
 }
 
-
+/**
+ * @brief Encode an MBR
+ *
+ * @param cfg the mbr configuration
+ * @param num_blocks the number of blocks on the destination or 0 if unknown
+ * @param output where to store the encoded MBR
+ * @return 0 if successful
+ */
 int mbr_create_cfg(cfg_t *cfg, uint32_t num_blocks, uint8_t output[512])
 {
     struct mbr_partition partitions[4];

--- a/src/mmc.h
+++ b/src/mmc.h
@@ -33,12 +33,12 @@ struct mmc_device {
 /**
  * @brief Run any initialization required for other mmc_* functions.
  */
-void mmc_init();
+void mmc_init(void);
 
 /**
  * @brief Free resources allocated by mmc_* functions.
  */
-void mmc_finalize();
+void mmc_finalize(void);
 
 /**
  * @brief Scan for SDCards and other removable media
@@ -47,6 +47,14 @@ void mmc_finalize();
  * @return the number of devices found
  */
 int mmc_scan_for_devices(struct mmc_device *devices, int max_devices);
+
+/**
+ * @brief Return the size of an SDCard/MMC device
+ * @param mmc_path the path
+ * @param end_offset the size of the device
+ * @return <0 on error
+ */
+int mmc_device_size(const char *mmc_path, off_t *end_offset);
 
 /**
  * @brief Open an SDCard/MMC device

--- a/src/mmc_bsd.c
+++ b/src/mmc_bsd.c
@@ -154,6 +154,20 @@ int mmc_eject(const char *mmc_device)
     return 0;
 }
 
+int mmc_device_size(const char *mmc_path, off_t *end_offset)
+{
+    *end_offset = 0;
+
+    int fd = open(mmc_path, O_RDONLY);
+    if (fd < 0)
+        return -1;
+
+    *end_offset = lseek(fd, 0, SEEK_END);
+    close(fd);
+
+    return *end_offset > 0 ? 0 : -1;
+}
+
 /**
  * @brief Open an SDCard/MMC device
  * @param mmc_path the path

--- a/src/mmc_linux.c
+++ b/src/mmc_linux.c
@@ -207,6 +207,14 @@ int mmc_scan_for_devices(struct mmc_device *devices, int max_devices)
     return device_count;
 }
 
+int mmc_device_size(const char *mmc_path, off_t *end_offset)
+{
+    // This function is called only when fwup has permission to
+    // write to the device so the "raw" method should always work.
+    *end_offset = mmc_device_size_raw(mmc_path);
+    return *end_offset > 0 ? 0 : -1;
+}
+
 int mmc_is_path_on_device(const char *file_path, const char *device_path)
 {
     // Stat both paths.

--- a/src/mmc_osx.c
+++ b/src/mmc_osx.c
@@ -246,6 +246,26 @@ static int authopen_fd(char * const pathname)
     }
 }
 
+int mmc_device_size(const char *mmc_path, off_t *end_offset)
+{
+    // Initialize to "unknown" size should anything go wrong.
+    *end_offset = 0;
+
+    DADiskRef disk = mmc_device_to_diskref(mmc_path);
+    int rc = -1;
+    if (disk) {
+        CFDictionaryRef info = DADiskCopyDescription(disk);
+        CFNumberRef cfsize = CFDictionaryGetValue(info, kDADiskDescriptionMediaSizeKey);
+        int64_t size;
+        CFNumberGetValue(cfsize, kCFNumberSInt64Type, &size);
+        *end_offset = size;
+        CFRelease(info);
+        CFRelease(disk);
+        rc = 0;
+    }
+    return rc;
+}
+
 /**
  * Return a file handle to the specified path for mmc devices
  *


### PR DESCRIPTION
This doesn't work on OSX and prevents "expand=true" from expanding a
partition to fill the device. To work around this, move the device size
determination to platform-specific code.

Fixes #100.