### PR TITLE
Make it more obvious that progress only goes up

### DIFF
--- a/src/progress.c
+++ b/src/progress.c
@@ -83,7 +83,7 @@ static void draw_progress_bar(struct fwup_progress *progress, int percent)
 
 static void output_progress(struct fwup_progress *progress, int percent)
 {
-    if (percent == progress->last_reported_percent)
+    if (percent <= progress->last_reported_percent)
         return;
 
     progress->last_reported_percent = percent;


### PR DESCRIPTION
While it's possible to trace the code and verify that progress can only
move upward, making the progress reporting code check too makes this
easier to convey to others. The hope is that it will be easier to defend
fwup in the future the next time someone thinks that its progress
reports went down.

In case it happens again and this commit message is seen, the cause of
progress reports "going down" was due to a UI re-sorting a device
listing that had several devices updating simultaneously. Visually, two
or more rows switched order and it looked as if one device's progress
was going down. However, on closer inspection, it was clear that device
ordering was changing and that update progress never went the wrong way.