### PR TITLE
Support SOURCE_DATE_EPOCH for reproducible builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ meta-platform        | Platform that this update runs on (e.g., rpi or bbb)
 meta-architecture    | Platform architectures (e.g., arm)
 meta-vcs-identifier  | A version control identifier for use in reproducing this image
 meta-misc            | Miscellaneous additional data. Format and contents are up to the user
-meta-creation-date   | Timestamp when the update was created (derived from ZIP metadata). If you want to force the timestamp, set the `NOW` environment variable.
+meta-creation-date   | Timestamp when the update was created (derived from ZIP metadata). For reproducible builds, set the [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/#idm55) environment variable.
 meta-fwup-version    | Version of fwup used to create the update (deprecated - no longer added since fwup 1.2.0)
 meta-uuid            | A UUID to represent this firmware. The UUID won't change even if the .fw file is digitally signed after creation (automatically generated)
 
@@ -649,6 +649,28 @@ file-resource rootfs.img {
         skip-holes = false
 }
 ```
+
+## Reproducible builds
+
+It's possible for the system time to be saved in various places when using
+`fwup`. This means that an archive with the same contents, but built at
+different times results in `.fw` files with different bytes. See
+[reproducible-builds.org](https://reproducible-builds.org/) for a discussion on
+this topic.
+
+`fwup` obeys the
+[`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/)
+ environment variable and will force all timestamps to the value of that
+variable when needed. Set `$SOURCE_DATE_EPOCH` to the number of seconds since
+midnight Jan 1, 1970 (run `date +%s`) to use this feature.
+
+A better way of comparing `.fw` archives, though, is to use the firmware UUID.
+The firmware UUID is computed from the contents of the archive rather than the
+bit-for-bit representation of the `.fw` file, itself. The firmware UUID is
+unaffected by timestamps (with or without `SOURCE_DATE_EPOCH`) or other things
+like compression algorithm improvements. This is not to say that
+`SOURCE_DATE_EPOCH` is not important, but that the UUID is an additional tool
+for ensuring that firmware updates are reproducible.
 
 # Firmware authentication
 

--- a/tests/162_source_date_epoch.test
+++ b/tests/162_source_date_epoch.test
@@ -1,0 +1,136 @@
+#!/bin/sh
+
+#
+# Create a firmware image and verify that it we create it a second later that
+# the bits are the same. This checks for timestamps being stored in the files.
+#
+
+. ./common.sh
+
+EXPECTED_METADATA=$WORK/expected_metadata
+ACTUAL_METADATA=$WORK/actual_metadata
+
+cat >$CONFIG <<EOF
+
+# +-----------------------------+
+# | MBR                         |
+# +-----------------------------+
+# | p0: Boot (Simulated)        |
+# +-----------------------------+
+# | p1*: Rootfs A (Simulated)   |
+# +-----------------------------+
+# | p1*: Rootfs B (Simulated)   |
+# +-----------------------------+
+# | p2: Data (Simulated)        |
+# +-----------------------------+
+
+define(BOOT_PART_OFFSET, 256) # at offset 128K
+define(BOOT_PART_COUNT, 256)
+define(ROOTFS_A_PART_OFFSET, 1024)
+define(ROOTFS_A_PART_COUNT, 1024)
+define(ROOTFS_B_PART_OFFSET, 2048)
+define(ROOTFS_B_PART_COUNT, 1024)
+define(APP_PART_OFFSET, 4096)
+define(APP_PART_COUNT, 1024)
+
+file-resource boot.stuff {
+        host-path = "${TESTFILE_1K}"
+}
+file-resource data.stuff {
+        host-path = "${TESTFILE_1K}"
+}
+file-resource rootfs.stuff {
+        host-path = "${TESTFILE_150K}"
+}
+
+mbr mbr-a {
+    partition 0 {
+        block-offset = \${BOOT_PART_OFFSET}
+        block-count = \${BOOT_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+    partition 1 {
+        block-offset = \${ROOTFS_A_PART_OFFSET}
+        block-count = \${ROOTFS_A_PART_COUNT}
+        type = 0x83 # Linux
+    }
+    partition 2 {
+        block-offset = \${APP_PART_OFFSET}
+        block-count = \${APP_PART_COUNT}
+        type = 0xc # FAT32
+    }
+    # partition 3 is unused
+}
+
+mbr mbr-b {
+    partition 0 {
+        block-offset = \${BOOT_PART_OFFSET}
+        block-count = \${BOOT_PART_COUNT}
+        type = 0xc # FAT32
+        boot = true
+    }
+    partition 1 {
+        block-offset = \${ROOTFS_B_PART_OFFSET}
+        block-count = \${ROOTFS_B_PART_COUNT}
+        type = 0x83 # Linux
+    }
+    partition 2 {
+        block-offset = \${APP_PART_OFFSET}
+        block-count = \${APP_PART_COUNT}
+        type = 0xc # FAT32
+    }
+    # partition 3 is unused
+}
+
+# This firmware task writes everything to the destination media
+task complete {
+    on-init {
+        mbr_write(mbr-a)
+    }
+    on-resource boot.stuff { raw_write(\${BOOT_PART_OFFSET}) }
+    on-resource data.stuff { raw_write(\${APP_PART_OFFSET}) }
+    on-resource rootfs.stuff { raw_write(\${ROOTFS_A_PART_OFFSET}) }
+}
+task upgrade.a {
+    # This task upgrades the A partition and runs when partition B
+    # is being used.
+    require-partition-offset(1, \${ROOTFS_B_PART_OFFSET})
+    on-init { mbr_write(mbr-a) }
+    on-resource rootfs.stuff { raw_write(\${ROOTFS_A_PART_OFFSET}) }
+}
+task upgrade.b {
+    # This task upgrades the B partition and runs when partition B
+    # is being used.
+    require-partition-offset(1, \${ROOTFS_A_PART_OFFSET})
+    on-init { mbr_write(mbr-b) }
+    on-resource rootfs.stuff { raw_write(\${ROOTFS_B_PART_OFFSET}) }
+}
+
+# This task is just needed to help support the unit test
+task dump_mbr_b {
+    on-init {
+        mbr_write(mbr-b)
+    }
+}
+EOF
+
+cat >$EXPECTED_METADATA <<EOF
+meta-creation-date="2019-09-19T03:22:13Z"
+meta-uuid="be8aa185-7a55-547b-de20-90abbef5418b"
+EOF
+
+# Create that setting SOURCE_DATE_EPOCH sets the date properly in the archive.
+export SOURCE_DATE_EPOCH=1568863333
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Check that the timestamp is what it should be
+$FWUP_APPLY_NO_CHECK -i $FWFILE -m > $ACTUAL_METADATA
+diff -w $EXPECTED_METADATA $ACTUAL_METADATA
+
+# Check that an archive created a couple seconds later is identical
+sleep 2
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE.2
+
+cmp $FWFILE $FWFILE.2
+

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -174,6 +174,7 @@ TESTS = 001_simple_fw.test \
 	158_include_anywhere.test \
 	159_include_error.test \
 	160_mbr_expand.test \
-	161_mbr_expand_error.test
+	161_mbr_expand_error.test \
+	162_source_date_epoch.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
This adds support for handling the $SOURCE_DATE_EPOCH environment
variable and documents how it can be used for reproducible builds.

See https://reproducible-builds.org/