### PR TITLE
Account for 128 KB writes for final size

### DIFF
--- a/src/fwup.c
+++ b/src/fwup.c
@@ -29,6 +29,7 @@
 #include <sodium.h>
 
 #include "../3rdparty/base64.h"
+#include "block_cache.h"
 #include "mmc.h"
 #include "util.h"
 #include "fwup_apply.h"
@@ -634,6 +635,11 @@ int main(int argc, char **argv)
             // Call out to platform-specific code to obtain a filehandle
             output_fd = mmc_open(mmc_device_path);
         }
+
+        // Trim the detected image size down to a multiple of the block cache
+        // segment size (128 KB) since since fwup only writes full blocks. If
+        // this isn't done, it is possible to write beyond the end of file.
+        end_offset &= ~(BLOCK_CACHE_SEGMENT_SIZE - 1);
 
         // Make sure that the output opened successfully and don't allow the
         // filehandle to be passed to child processes.

--- a/tests/166_gpt_expand-generate.sh
+++ b/tests/166_gpt_expand-generate.sh
@@ -16,6 +16,8 @@ rootfs_a_part_uuid=fcc205c8-2f1c-4dcd-bef4-7b209aa15cca
 rootfs_b_part_uuid=4E69D2CD-028F-40CE-BBEE-94FB353B424C
 app_part_uuid=9558571B-1DFC-4C3F-8DB4-A8A564FB99A4
 
+gpt_size=33
+
 # Boot partition offset and size, in 512-byte sectors
 efi_part_start=1024
 efi_part_size=1024
@@ -25,9 +27,11 @@ rootfs_b_part_start=4096
 rootfs_b_part_size=2048
 app_part_start=8192
 app_part_size=4096
-app_part_expanded_size=12288
 
-gpt_size=33
+# Force the image size to be a multiple of 128 KB. fwup will round
+# to the nearest multiple since it only works in 128 KB chunks.
+image_expanded_size=20736
+app_part_expanded_size=$(( image_expanded_size - gpt_size - 1 - app_part_start ))
 
 first_lba=$(( 1 + gpt_size ))
 last_lba=$(( app_part_start + app_part_size ))
@@ -35,7 +39,6 @@ last_lba_expanded=$(( app_part_start + app_part_expanded_size ))
 
 # Disk image size in 512-byte sectors
 image_size=$(( last_lba + gpt_size + 1 ))
-image_expanded_size=$(( last_lba_expanded + gpt_size + 1 ))
 
 primary_gpt_lba=0
 secondary_gpt_lba=$(( image_size - gpt_size ))

--- a/tests/166_gpt_expand.test
+++ b/tests/166_gpt_expand.test
@@ -91,25 +91,25 @@ cp $WORK/expected-primary-gpt.img $WORK/unexpanded.img
 dd if=$WORK/expected-secondary-gpt.img of=$WORK/unexpanded.img bs=512 seek=12289 conv=notrunc
 
 base64_decodez >$WORK/expected-primary-gpt2.img <<EOF
-H4sIABNvu10AA+3QTyiDYRwH8N8WkYNtLg6zbE7SUMpp5m82MrMWcdjllS0rZb1bmjQpUxxwwMFO
-VhQukh2GWnGQ0RxGkYvLbstKOaitXo+8O+yiXkrU9/P21PPv+37fXiL4z+SUEQRBxmY6m/T00H63
-qVdr67APEsnIwXZMxorAx4lMvJF/a00+Iq7T2a7Iml7ds3hUfl2W3lPJxeM5cUyEnqPSvwd+W623
-7qz6Lak66aOteGvcoOH99iUaNy88RV+OZ11BKvq8J5QU5pzkIjfVk4c44slHDTTFdjg2k0Z5/+hO
-6VushxO68F0odntZfJ6rakz0x15ntKGw44pKxX5FYY6nSfb4WKeXdXNsOMnP1k0/7E8k3dZV+U37
-aWY922zotJBS7K/8qn/02/0HxgvFfJA3r0wb3Q/mQEo9PLKR07RZliO7O2PZzW3Siv0DhTmO/XmP
-xC4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPjb3gHtLyCBAEIAAA==
+H4sIAEOfxV0AA+3TTyiDYRwH8N/WRA62nRxmGSdprJTTzN+YZdZaxGGXV7a8pax3S5NImeKAAw52
+sqJwkezgT604yGgOo0jhspPVSjmorV6P9jrMQY0S9f28PfX8+f2eb+9bLxH8Z3JKiaIoYzPRnn93
+73Z7h0Vnb3H0EMnIyXY0ioTi/UQmVXzcWimtH6R1Mt0WXtJrOmf3Si6Kk1tquXQ+JY0ni8H5jdeB
+X1blrT4uf42rD7toLdoYNWoFv2OOhswzj/vPB5PuACmydWJhbp+L3MRTDXmII4F8VEujbIdjs/yo
+bu74hL7BtjtcEboORq7OCk4yZYZYd+RlXBcMOc+pSMpX5vYJNMIeH8v0smyODRf52bruh/mxOG9b
+lF82H6WW0/XGViuppPzSr/IHvp2/YzpVTgcE88KYib81TyQ0ff0rGW2TdT68uTGYXl0nXbbu/tPf
+zbEv78kzCwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/rY3o2m94gBCAAA=
 EOF
 base64_decodez >$WORK/expected-secondary-gpt2.img <<EOF
-H4sIABNvu10AA+3QPUiCQRgH8McoiobUqcEkbYqwD4Ims0/KIjORoAaXN1J8QUheJYwoAg1qqIZq
-yCmhoKaIHCxBqCGysMGCoqXFTQqChkAhr7oGl8CEaPj/joO75+7hf1y9p+G09i2pPBmi7XhHXK+W
-fNZlchoXHyMvx/OOAJXSp/dyymMnB4nUSG4SSCIvNdE0qwhsVRjF3YOY0rWbD13a0G0wdnNRdpat
-aU4Mx15nNcGQ7ZIqeL48v0+iKTa8LNPDsgU27eRj+9Yi8xNJ0bxWct0Vfd7ItOl7TKTg+dU/5U/8
-Ov/AcC73ByTj6oxBvDfOpVRj45tZdadpJby3O5nZ2iENzx/J7xPYz7sLzAIAAAAAAAAAAAAAAAAA
-AAAAAAAAAAAAAAAAAAAAAID/q69/UGPpto4SycjG9s6ov+WjrrV8ncv4vbrvBl5PZ3rD6zrVwNJR
-1VVlel8p4/UFPl3Bp8hfvB+KkwOi5yMAAEIAAA==
+H4sIAEOfxV0AA+3bPUiCQRgH8McoiobUqcEka4qwhKDJ7JMyyUQkyMHljZReCJJXCSOKIIMaqqEa
+ckooqCkihz5AqCGysMGCIkgXlxKCoCFQ0KtucQlMiIb/7zju7uGOP3f7NXgaz2o/YsqTAdqKtEf0
+aslnW6Ix40Li6O141uWnUvqSLac8TnKRSE3kJoEk8lIzTbKKwGaFUdw/ikltm+VgvC54FwjfXpad
+Z2p00cHw+7QmEHRcUQXPl+efk2iCNS/L9LBsgXUn+di6pcj8aEy0rJbcdJ6+rqdb9d1mUvD86p/y
+R36dv2+4kM/7JePKlEF8MM4kVcP2jYy6w7wc2t0ZTW9uk+Z735M1/5zAXt5dYBYAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAD8X719Jo21yzZEJCMHW8ft0efPepb/N5fxffV8jPN6Kt0TWtOq
++hcPq64rU3vKBK/P8f5i0jn+5AJQlBysljDEAEIAAA==
 EOF
 cp $WORK/expected-primary-gpt2.img $WORK/expanded.img
-dd if=$WORK/expected-secondary-gpt2.img of=$WORK/expanded.img bs=512 seek=20481 conv=notrunc
+dd if=$WORK/expected-secondary-gpt2.img of=$WORK/expanded.img bs=512 seek=20703 conv=notrunc
 
 # Create the firmware file, then "burn it"
 $FWUP_CREATE -c -f $CONFIG -o $FWFILE
@@ -120,9 +120,9 @@ $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
 cmp_bytes 6308864 $WORK/unexpanded.img $IMGFILE
 
 # Now make the image file larger to see that the final partition is larger
-dd if=/dev/zero of=$IMGFILE bs=512 count=20514 2>/dev/null
+dd if=/dev/zero of=$IMGFILE bs=512 count=20736 2>/dev/null
 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
-cmp_bytes 10503168 $WORK/expanded.img $IMGFILE
+cmp $WORK/expanded.img $IMGFILE
 
 # Check that the verify logic works on this file
 $FWUP_VERIFY -V -i $FWFILE


### PR DESCRIPTION
If the destination is not a multiple of 128 KB, it's possible to write
beyond the end since fwup writes in 128 KB blocks. This reduces the
destination length to the nearest multiple so that that can't happen.

This fixes an issue where writing the secondary GPT partition would fail
due to the added padding in the final block. Unfortunately, for drives
that are not a multiple of 128 KB, the secondary GPT is non-compliant
since it's not at the last block. I would assume that whatever logic
recovers from a corrupt primary GPT won't work since the GPT header
won't be at the expected LBA.

This should be fixed. However, as a minor consolation, manufactoring
Flash programmers typically take image files as input where the size of
the image is much less than the destination Flash size. The secondary
GPT header is going to be placed incorrectly by design and if it's
important to update it, then that will need to be done at runtime.