### PR TITLE
Switch disk encryption key to hex encoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ on-resource fs.squashfs {
 In the above example, the `SECRET_KEY` is expected to come from an environment
 variable being set on the device when applying the firmware update. You could,
 of course, hard-code the secret key in the configuration file to test things
-out. The key is base64-encoded.
+out. The key is hex-encoded.
 
 Then, on the device, mount the SquashFS partition but use `dm-crypt`. The
 process will look something like this:

--- a/tests/171_disk_crypto_aes_cbc_plain_deprecated.test
+++ b/tests/171_disk_crypto_aes_cbc_plain_deprecated.test
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 #
-# Test writing a resource to an encrypted disk
+# Test aes-cbc-plain with the secret base64 encoded.
 #
-# Note: fwup and dmcrypt pad blocks differently, so test files need to be
-# multiples of 512.
+# This is a deprecated feature and is kept around since 1.5.0 supported it.
+# Use regular hex encoding for secrets.
 #
 
 . ./common.sh
@@ -15,7 +15,7 @@ file-resource subdir/TEST {
 }
 
 task complete {
-        on-resource subdir/TEST { raw_write(1, "cipher=aes-cbc-plain", "secret=8e9c0780fd7f5d00c18a30812fe960cfce71f6074dd9cded6aab2897568cc856") }
+        on-resource subdir/TEST { raw_write(1, "cipher=aes-cbc-plain", "secret=jpwHgP1/XQDBijCBL+lgz85x9gdN2c3taqsol1aMyFY=") }
 }
 EOF
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -183,6 +183,7 @@ TESTS = 001_simple_fw.test \
 	167_gpt_16_parts.test \
 	168_gpt_flags.test \
 	169_disk_crypto_aes_cbc_plain.test \
-	170_disk_crypto_catches_errors.test
+	170_disk_crypto_catches_errors.test \
+	171_disk_crypto_aes_cbc_plain_deprecated.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
This matches how keys are passed to dm-crypt and makes it less
cumbersome to handle keys.

UPDATE: The original commit was a breaking change. That's been fixed. Base64 is still supported.