### PR TITLE
Support building minimal versions of fwup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
           env: MODE=windows
         - os: linux
           compiler: gcc
+          env: MODE=minimal
+        - os: linux
+          compiler: gcc
           env: MODE=raspberrypi
         - os: linux
           compiler: gcc

--- a/README.md
+++ b/README.md
@@ -90,10 +90,13 @@ or clone this repository. Then read one of the following files:
 * [Raspbian build instructions](docs/build_rpi.md)
 * [FreeBSD/NetBSD/OpenBSD build instructions](docs/build_bsd.md)
 
-When building from source, please verify that the regression test pass
-on your system (run `make check`) before using `fwup` in production. While
-the tests usually pass, they have found minor issues in third party libraries in the
-past that really should be fixed.
+When building from source, please verify that the regression test pass on your
+system (run `make check`) before using `fwup` in production. While the tests
+usually pass, they have found minor issues in third party libraries in the past
+that really should be fixed.
+
+NOTE: For space-constrained target devices, use `./configure
+--enable-minimal-build` to trim functionality that's rarely used.
 
 # Invoking
 

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,10 @@ AS_CASE([$host_os],
         [darwin*], [LIBS="$LIBS -framework CoreFoundation -framework DiskArbitration"]
         )
 
+# Limit functionality for minimal size
+AC_ARG_ENABLE(minimal-build,[AS_HELP_STRING([--enable-minimal-build], [create minimal build (only supports applying updates)])])
+AS_IF([test "x${enable_minimal_build}" = "xyes" ], [AC_DEFINE([FWUP_MINIMAL], [1], [Defined if functionality should be limited to applying updates])])
+
 # Shell completion
 AC_ARG_WITH([bash-completion-dir],
     AS_HELP_STRING([--with-bash-completion-dir[=PATH]],

--- a/scripts/build_and_test_minimal.sh
+++ b/scripts/build_and_test_minimal.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#
+# Build both full featured and minimal versions of fwup and test the minimal one
+#
+
+set -e
+set -v
+
+mkdir full_featured
+mkdir minimal
+
+cd minimal
+../configure --enable-minimal-build
+make -j4
+cd ..
+
+cd full_featured
+../configure
+make -j4
+cd ..
+
+# Go back and test the minimal version of fwup, but use the full-featured one
+# to create the archives.
+cd minimal
+FWUP_CREATE=$PWD/../full_featured/src/fwup make -j4 check
+

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -5,7 +5,7 @@
 #
 # Inputs:
 #    TRAVIS_OS_NAME - "linux" or "osx"
-#    MODE           - "static", "dynamic", "windows", or "raspberrypi"
+#    MODE           - "static", "dynamic", "windows", "raspberrypi", or "minimal"
 #
 # Static builds use scripts to download libarchive, libconfuse, and libsodium,
 # so those are only installed on shared library builds.
@@ -21,6 +21,10 @@ case "${TRAVIS_OS_NAME}-${MODE}" in
     *-static)
         # If this is a static build, run 'build_pkg.sh'
         bash -v scripts/build_pkg.sh
+        exit 0
+        ;;
+    linux-minimal)
+        bash -v scripts/build_and_test_minimal.sh
         exit 0
         ;;
     linux-dynamic)
@@ -70,5 +74,4 @@ else
 fi
 make -j4
 make -j4 check
-
 

--- a/scripts/ci_install_deps.sh
+++ b/scripts/ci_install_deps.sh
@@ -54,7 +54,7 @@ if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then
             sudo apt-get update
             sudo apt-get install -qq gcc-mingw-w64-x86-64 wine
             ;;
-        singlethread|dynamic)
+        singlethread|dynamic|minimal)
             sudo apt-get install -qq libarchive-dev
             install_confuse
             install_sodium

--- a/src/fwfile.c
+++ b/src/fwfile.c
@@ -24,6 +24,7 @@
 #include <archive_entry.h>
 #include <sodium.h>
 
+#ifndef FWUP_MINIMAL
 int fwfile_add_meta_conf(cfg_t *cfg, struct archive *a, const unsigned char *signing_key)
 {
     char *configtxt;
@@ -81,3 +82,4 @@ int fwfile_add_meta_conf_str(const char *configtxt, int configtxt_len,
 
     return 0;
 }
+#endif

--- a/src/fwup_create.c
+++ b/src/fwup_create.c
@@ -32,6 +32,8 @@
 #include <fcntl.h>
 #include <assert.h>
 
+#ifndef FWUP_MINIMAL
+
 struct calc_metadata_state
 {
     struct sparse_file_map sfm;
@@ -353,3 +355,4 @@ cleanup:
 
     return rc;
 }
+#endif // FWUP_MINIMAL

--- a/src/fwup_genkeys.c
+++ b/src/fwup_genkeys.c
@@ -29,6 +29,8 @@
 
 #include "util.h"
 
+#ifndef FWUP_MINIMAL
+
 static int save_key(const char *name, unsigned char *key, size_t key_len)
 {
     int rc = 0;
@@ -89,3 +91,5 @@ int fwup_genkeys(const char *output_prefix)
 
     return 0;
 }
+
+#endif // FWUP_MINIMAL

--- a/src/fwup_sign.c
+++ b/src/fwup_sign.c
@@ -27,6 +27,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+#ifndef FWUP_MINIMAL
+
 /**
  * @brief Sign a firmware update file
  * @param input_filename the firmware update filename
@@ -162,3 +164,4 @@ cleanup:
     return rc;
 
 }
+#endif // FWUP_MINIMAL

--- a/src/sparse_file.c
+++ b/src/sparse_file.c
@@ -344,6 +344,7 @@ int sparse_file_read_next_data(struct sparse_file_read_iterator *iterator, int f
     return 0;
 }
 
+#ifndef FWUP_MINIMAL
 /**
  * @brief Check whether sparse files are supported on a filesystem
  *
@@ -384,3 +385,4 @@ cleanup:
     ERR_RETURN("Sparse file supported not compiled into fwup.");
 #endif
 }
+#endif


### PR DESCRIPTION
This change makes it possible to trim down the footprint of fwup. This
primarily removes the capability of creating firmware archives since
that is almost never used on devices.

To use:

```sh
./configure --enable-minimal-build.
```

Note that the regression tests will fail since archives can't be
created. The solution to this is to build a full-featured and minimal
version of fwup and use the full-featured one to create the archives.
See the `build_and_test_minimal.sh` script for details.