### PR TITLE
Change the skip-holes default to off

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,12 +678,13 @@ zeros and automatically create holes. Programs like `dd(1)` can do this, though,
 so it is crucial that you do not run files through `dd` to make then sparser
 before passing them to `fwup`.
 
-To turn this feature off, set `skip-holes` on the resource to `false`:
+This feature is off by default. To turn this feature on, set `skip-holes` on
+the resource to `true`:
 
 ```conf
 file-resource rootfs.img {
         host-path = "output/images/rootfs.img"
-        skip-holes = false
+        skip-holes = true
 }
 ```
 

--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -422,7 +422,7 @@ static int cb_validate_on_resource(cfg_t *cfg, cfg_opt_t *opt)
 static cfg_opt_t file_resource_opts[] = {
     CFG_FUNC("include", &cb_include),
     CFG_STR("host-path", 0, CFGF_NONE),
-    CFG_BOOL("skip-holes", cfg_true, CFGF_NONE),
+    CFG_BOOL("skip-holes", cfg_false, CFGF_NONE),
 
 #if (SIZEOF_INT == 4 && SIZEOF_OFF_T > 4)
     // If we're on a 32-bit machine that has large file offsets,

--- a/tests/090_sparse_write.test
+++ b/tests/090_sparse_write.test
@@ -38,6 +38,7 @@ dd if=$TESTFILE_4K bs=1k seek=1024 of=$SPARSE_FILE conv=sync,notrunc 2>/dev/null
 cat >$CONFIG <<EOF
 file-resource sparsefile {
         host-path = "${SPARSE_FILE}"
+        skip-holes = true
 }
 
 task complete {

--- a/tests/091_sparse_write2.test
+++ b/tests/091_sparse_write2.test
@@ -49,6 +49,7 @@ done
 cat >$CONFIG <<EOF
 file-resource sparsefile {
         host-path = "${SPARSE_FILE}"
+        skip-holes = true
 }
 
 task complete {

--- a/tests/092_sparse_write3.test
+++ b/tests/092_sparse_write3.test
@@ -47,6 +47,7 @@ done
 cat >$CONFIG <<EOF
 file-resource sparsefile {
         host-path = "${SPARSE_FILE}"
+        skip-holes = true
 }
 
 task complete {

--- a/tests/093_sparse_concat.test
+++ b/tests/093_sparse_concat.test
@@ -40,39 +40,51 @@ dd if=$TESTFILE_4K of=$TESTFILE_B bs=1k seek=188 conv=sync 2>/dev/null
 cat >$CONFIG <<EOF
 file-resource a {
         host-path = "${TESTFILE_A}"
+        skip-holes = true
 }
 file-resource b {
         host-path = "${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource aa {
         host-path = "${TESTFILE_A};${TESTFILE_A}"
+        skip-holes = true
 }
 file-resource ab {
         host-path = "${TESTFILE_A};${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource ba {
         host-path = "${TESTFILE_B};${TESTFILE_A}"
+        skip-holes = true
 }
 file-resource bb {
         host-path = "${TESTFILE_B};${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource aab {
         host-path = "${TESTFILE_A};${TESTFILE_A};${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource aba {
         host-path = "${TESTFILE_A};${TESTFILE_B};${TESTFILE_A}"
+        skip-holes = true
 }
 file-resource abb {
         host-path = "${TESTFILE_A};${TESTFILE_B};${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource baa {
         host-path = "${TESTFILE_B};${TESTFILE_A};${TESTFILE_A}"
+        skip-holes = true
 }
 file-resource bab {
         host-path = "${TESTFILE_B};${TESTFILE_A};${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource bba {
         host-path = "${TESTFILE_B};${TESTFILE_B};${TESTFILE_A}"
+        skip-holes = true
 }
 EOF
 

--- a/tests/094_sparse_concat2.test
+++ b/tests/094_sparse_concat2.test
@@ -46,39 +46,51 @@ dd if=$TESTFILE_4K of=$TESTFILE_B bs=1k seek=8 conv=sync 2>/dev/null
 cat >$CONFIG <<EOF
 file-resource a {
         host-path = "${TESTFILE_A}"
+        skip-holes = true
 }
 file-resource b {
         host-path = "${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource aa {
         host-path = "${TESTFILE_A};${TESTFILE_A}"
+        skip-holes = true
 }
 file-resource ab {
         host-path = "${TESTFILE_A};${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource ba {
         host-path = "${TESTFILE_B};${TESTFILE_A}"
+        skip-holes = true
 }
 file-resource bb {
         host-path = "${TESTFILE_B};${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource aab {
         host-path = "${TESTFILE_A};${TESTFILE_A};${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource aba {
         host-path = "${TESTFILE_A};${TESTFILE_B};${TESTFILE_A}"
+        skip-holes = true
 }
 file-resource abb {
         host-path = "${TESTFILE_A};${TESTFILE_B};${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource baa {
         host-path = "${TESTFILE_B};${TESTFILE_A};${TESTFILE_A}"
+        skip-holes = true
 }
 file-resource bab {
         host-path = "${TESTFILE_B};${TESTFILE_A};${TESTFILE_B}"
+        skip-holes = true
 }
 file-resource bba {
         host-path = "${TESTFILE_B};${TESTFILE_B};${TESTFILE_A}"
+        skip-holes = true
 }
 EOF
 

--- a/tests/150_no_sparse.test
+++ b/tests/150_no_sparse.test
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 #
-# Test that fwup doesn't do sparse file processing when told not to
+# Test that fwup doesn't do sparse file processing by default
+# I.e., skip-holes defaults to false
 #
 
 . "$(cd "$(dirname "$0")" && pwd)/common.sh"
@@ -38,7 +39,6 @@ dd if=$TESTFILE_4K bs=1k seek=1024 of=$SPARSE_FILE conv=sync,notrunc 2>/dev/null
 cat >$CONFIG <<EOF
 file-resource sparsefile {
         host-path = "${SPARSE_FILE}"
-        skip-holes = false
 }
 
 task complete {


### PR DESCRIPTION
Fwup has a feature where it can respect sparse file holes and recreate
them on devices. This can majorly save time writing large ext2/4
partitions to Flash. It has a couple gotchas that make it tricky to use:

1. If programs creating the sparse files create holes to initialize runs
   of zeros, those holes may not contain zeros on the device. It would be
   nice if the programs wrote zeros, but that can't be enforced.
2. Sparse hole sizes and offsets depend on the filesystems where the
   archives are created. This introduces another variation when trying
   make reproducible builds.
3. Sparse files are incompatible with the upcoming binary delta feature.
   In other words, any files that are stored as sparse ones cannot be
   turned into patches.

Since sparse file reproduction is an optimization, it was decided to
disable it by default. This will prevent it from accidentally getting
used and preventing binary delta support.

Overall, this feature turned out to not be used as much as anticipated
since so many fwup users are not writing large ext2/4 partitions to
their devices. Users who do this can still take advantage of sparse
files by adding "skip-hole = true" to the file resources of interest.