### PR TITLE
Update progress bar to report input processed

### DIFF
--- a/src/archive_open.h
+++ b/src/archive_open.h
@@ -17,9 +17,13 @@
 #ifndef ARCHIVE_OPEN_H
 #define ARCHIVE_OPEN_H
 
-#include <archive.h>
+#include <stdlib.h>
+#include <stdint.h>
 
-int fwup_archive_open_filename(struct archive *a, const char *filename);
+struct fwup_progress;
+struct archive;
+
+int fwup_archive_open_filename(struct archive *a, const char *filename, struct fwup_progress *progress);
 int fwup_archive_read_data_block(struct archive *a, const void **buff, size_t *s, int64_t *o);
 
 #endif // ARCHIVE_OPEN_H

--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -787,7 +787,7 @@ int cfgfile_parse_fw_meta_conf(const char *filename, cfg_t **cfg, unsigned char 
     unsigned char *meta_conf_signature = NULL;
     struct archive *a = archive_read_new();
     archive_read_support_format_zip(a);
-    rc = fwup_archive_open_filename(a, filename);
+    rc = fwup_archive_open_filename(a, filename, NULL);
     if (rc != ARCHIVE_OK)
         ERR_CLEANUP_MSG("%s", archive_error_string(a));
 

--- a/src/fwup_apply.c
+++ b/src/fwup_apply.c
@@ -467,7 +467,7 @@ int fwup_apply(const char *fw_filename,
     pd.a = archive_read_new();
 
     archive_read_support_format_zip(pd.a);
-    int arc = fwup_archive_open_filename(pd.a, fw_filename);
+    int arc = fwup_archive_open_filename(pd.a, fw_filename, progress);
     if (arc != ARCHIVE_OK)
         ERR_CLEANUP_MSG("%s", archive_error_string(pd.a));
 

--- a/src/fwup_verify.c
+++ b/src/fwup_verify.c
@@ -192,7 +192,7 @@ int fwup_verify(const char *input_filename, unsigned char * const *public_keys)
     if (!input_filename)
         ERR_CLEANUP_MSG("Specify an input firmware file");
 
-    rc = fwup_archive_open_filename(a, input_filename);
+    rc = fwup_archive_open_filename(a, input_filename, NULL);
     if (rc != ARCHIVE_OK)
         ERR_CLEANUP_MSG("%s", archive_error_string(a));
 

--- a/src/progress.c
+++ b/src/progress.c
@@ -67,17 +67,19 @@ static void draw_progress_bar(struct fwup_progress *progress, int percent)
     static const char fifty_equals[] = "==================================================";
 
     if (progress->total_units <= 0) {
-        printf("\r|%-" PROGRESS_BITS_STR ".*s| %d%%",
-               percent * PROGRESS_BITS / 100, fifty_equals,
-               percent);
-    } else {
-        off_t units = find_natural_units(progress->total_units);
-        printf("\r|%-" PROGRESS_BITS_STR ".*s| %d%% (%.2f / %.2f) %s",
-               percent * PROGRESS_BITS / 100, fifty_equals,
+        printf("\r%3d%% [%-" PROGRESS_BITS_STR ".*s]",
                percent,
-               ((double) progress->current_units) / units,
-               ((double) progress->total_units) / units,
-               units_to_string(units));
+               percent * PROGRESS_BITS / 100, fifty_equals);
+    } else {
+        off_t read_units = find_natural_units(progress->input_bytes);
+        off_t written_units = find_natural_units(progress->current_units);
+        printf("\r%3d%% [%-" PROGRESS_BITS_STR ".*s] %.2f %s in / %.2f %s out \b\b",
+               percent,
+               percent * PROGRESS_BITS / 100, fifty_equals,
+               ((double) progress->input_bytes) / read_units,
+               units_to_string(read_units),
+               ((double) progress->current_units) / written_units,
+               units_to_string(written_units));
     }
 }
 
@@ -129,6 +131,7 @@ void progress_init(struct fwup_progress *progress,
     progress->start_time = 0;
     progress->low = progress_low;
     progress->range = progress_high - progress_low;
+    progress->input_bytes = 0;
 
     output_progress(progress, progress_low);
 }

--- a/src/progress.h
+++ b/src/progress.h
@@ -38,7 +38,11 @@ struct fwup_progress {
     // This counts up as we make progress.
     uint64_t current_units;
 
-    // The most recent progress reported is cached to avoid unnecessary context switching/IO
+    // Keep track of the current progress. Reports are never sent that
+    // duplicate previous reports.
+    //
+    // NOTE: The percent is 100 * current_units / total_units. (I.e., roughly
+    // written bytes out of the total to write)
     int last_reported_percent;
 
     // This is the starting progress value (normally 0 for 0%)
@@ -49,6 +53,9 @@ struct fwup_progress {
 
     // If the mode supports it, this is the start time of the update in milliseconds
     int start_time;
+
+    // Track the number of input bytes processed.
+    uint64_t input_bytes;
 };
 
 extern enum fwup_progress_option fwup_progress_mode;

--- a/tests/020_normal_progress.test
+++ b/tests/020_normal_progress.test
@@ -30,18 +30,24 @@ EOF
 
 $FWUP_CREATE -c -f $CONFIG -o $FWFILE
 
-# Run the command and turn the `\r`s into periods to make
-# it easy to compare with the expected output. The
-# call to sed is to discard the final `\r` that's present
-# on Windows.
+# Run the command and turn the `\r`s into `\n`'s to make it easy to compare
+# with the expected output. The first call to sed trims the byte counts which
+# can vary slightly depending on libarchive versions in use. The second call to
+# sed is to discard the final empty line that's present on Windows.
 $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete \
-    | tr '\r' '.' \
-    | sed 's/\.$//g' \
+    | tr '\r' '\n' \
+    | sed 's/].*$/]/g' \
+    | sed '/^$/d' \
     | grep -v '^Elapsed time' \
     > $WORK/actual_output.txt
 
 cat >$WORK/expected_output.txt <<EOF
-.|                                    | 0%.|=========                           | 25% (1.02 / 4.10) KB.|==================                  | 50% (2.05 / 4.10) KB.|===========================         | 75% (3.07 / 4.10) KB.|=================================== | 99% (4.10 / 4.10) KB.|====================================| 100% (4.10 / 4.10) KB
+  0% [                                    ]
+ 25% [=========                           ]
+ 50% [==================                  ]
+ 75% [===========================         ]
+ 99% [=================================== ]
+100% [====================================]
 Success!
 EOF
 diff $WORK/expected_output.txt $WORK/actual_output.txt

--- a/tests/104_info_msg.test
+++ b/tests/104_info_msg.test
@@ -50,11 +50,11 @@ $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete \
     | grep -v '^Elapsed time' \
     > $WORK/actual_output.txt
 cat >$WORK/expected_output.txt <<EOF
-.|                                                  | 0%.~[Kfwup: 1.bin
+.  0% [                                    ].~[Kfwup: 1.bin
 .~[Kfwup: 2.bin
 .~[Kfwup: 3.bin
 .~[Kfwup: 4.bin
-.|====================================| 100%
+.100% [====================================]
 Success!
 EOF
 diff -w $WORK/expected_output.txt $WORK/actual_output.txt

--- a/tests/141_exit_handshake.test
+++ b/tests/141_exit_handshake.test
@@ -13,20 +13,21 @@ EOF
 
 $FWUP_CREATE -c -f $CONFIG -o $FWFILE
 
-# Run the command and turn the `\r`s into periods to make
+# Run the command and turn the `\r`s into newlines to make
 # it easy to compare with the expected output. The
 # call to sed is to discard the final `\r` that's present
 # on Windows.
 cat /dev/null | $FWUP_APPLY --exit-handshake -a -d $IMGFILE -i $FWFILE -t complete \
-    | tr '\r' '.' \
     | tr '\032' '@' \
     | tr '\0' '!' \
-    | sed 's/\.$//g' \
+    | tr '\r' '\n' \
+    | sed '/^$/d' \
     | grep -v '^Elapsed time' \
     > $WORK/actual_output.txt
 
 cat >$WORK/expected_output.txt <<EOF
-.|                                    | 0%.|====================================| 100%
+  0% [                                    ]
+100% [====================================]
 Success!
 @!
 EOF


### PR DESCRIPTION
The progress bar still moves based on output written since that's
more correlated with the update duration. However, it wasn't obvious
that the firmware update sizes were almost always much smaller than what
was written. This makes it more obvious and seems like useful status.