### PR TITLE
Quick fail on any write error

### DIFF
--- a/src/block_cache.h
+++ b/src/block_cache.h
@@ -105,6 +105,7 @@ int block_cache_trim_after(struct block_cache *bc, off_t offset, bool hwtrim);
 int block_cache_pwrite(struct block_cache *bc, const void *buf, size_t count, off_t offset, bool streamed);
 int block_cache_pread(struct block_cache *bc, void *buf, size_t count, off_t offset);
 int block_cache_flush(struct block_cache *bc);
+void block_cache_reset(struct block_cache *bc);
 int block_cache_free(struct block_cache *bc);
 
 #endif // BLOCK_CACHE_H

--- a/tests/117_on_error.test
+++ b/tests/117_on_error.test
@@ -14,11 +14,14 @@ file-resource 1K.bin {
 	host-path = "${TESTFILE_1K}"
 }
 
-task complete {
+task mkfs {
     on-init {
         fat_mkfs(\${BOOT_PART_OFFSET}, \${BOOT_PART_COUNT})
     }
+}
+task complete {
     on-resource 1K.bin {
+        fat_touch(\${BOOT_PART_OFFSET}, "wont_make_it_out_of_cache")
         fat_write(\${BOOT_PART_OFFSET}, "this/will/fail/1k.bin")
     }
     on-error {
@@ -29,6 +32,7 @@ EOF
 
 # Create the firmware file, then "burn it"
 $FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t mkfs
 echo $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
 if $FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete; then
     echo "The fat_write should have failed."


### PR DESCRIPTION
Previously, there was an attempt to flush inflight writes when errors
occur. This stops this from happening. I.e., any error will stop all writes
that fwup still has not issued to the OS.

The reason for this change is that if a write error occurs, the call to
flush could result in another error that would be reported to users instead
of the original one. The first one was closer to the root cause and more
helpful when debugging.

Also, I have a different opinion now with fwup and writes after errors. I
believe that my previous logic for flushing is wrong, and the simplest
course of action is for fwup to stop as soon as an unrecoverable error has
been hit.