### PR TITLE
Add boot convenience flag for GPT partitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,12 +545,21 @@ gpt my-gpt {
         type = 44479540-f297-41b2-9af7-d131d5f0458a # Rootfs type UUID
         guid = fcc205c8-2f1c-4dcd-bef4-7b209aa15cca # Another uuidgen'd UUID
         name = "rootfs.ext2"
+        flags = 0xc000000000000
+        boot = true
     }
 }
 ```
 
-Call `gpt_write` to tell `fwup` to write the protective MBR and primary and backup
-GPT tables.
+See the GPT partition entry header specification for what `partition` fields
+mean and how to use them. Of the fields, `name`, `flags`, and `boot` are
+optional and default to an empty string, zero, or false. The `flags` field holds
+the integer value of the partition attribute field. It is a 64-bit number. Bit
+2, the legacy BIOS bootable flag, can also be set by specifying `boot = true`.
+Both `boot` and `flags` can be specified in a `partition` block.
+
+Call `gpt_write` to tell `fwup` to write the protective MBR and primary and
+backup GPT tables.
 
 ## U-Boot environment
 

--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -483,6 +483,7 @@ static cfg_opt_t gpt_partition_opts[] = {
     CFG_STR("name", "", CFGF_NONE),
     CFG_STR("flags", "0", CFGF_NONE), // Special case: use a string to support unsigned 64-bit number
     CFG_BOOL("expand", cfg_false, CFGF_NONE),
+    CFG_BOOL("boot", cfg_false, CFGF_NONE),
     CFG_IGNORE_UNKNOWN
     CFG_END()
 };

--- a/src/gpt.c
+++ b/src/gpt.c
@@ -19,6 +19,7 @@
 #include "util.h"
 
 #include <errno.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -229,11 +230,6 @@ static int gpt_cfg_to_partitions(cfg_t *cfg, struct gpt_partition *partitions, i
         char *endptr;
         unsigned long block_offset = strtoul(unverified_block_offset, &endptr, 0);
 
-        const char *unverified_flags = cfg_getstr(partition, "flags");
-        if (!unverified_flags)
-            ERR_RETURN("partition %d's flags is required", partition_ix);
-        uint64_t flags = strtoull(unverified_flags, &endptr, 0);
-
         // strtoul returns error by returning ULONG_MAX and setting errno.
         // Values bigger than 2^32-1 won't fit in the MBR, so report an
         // error for those too.
@@ -249,6 +245,29 @@ static int gpt_cfg_to_partitions(cfg_t *cfg, struct gpt_partition *partitions, i
             ERR_RETURN("partition %d's block-count must be specified and less than 2^31 - 1", partition_ix);
 
         partitions[partition_ix].expand_flag = cfg_getbool(partition, "expand");
+
+        const char *unverified_flags_str = cfg_getstr(partition, "flags");
+        uint64_t flags = 0;
+        if (unverified_flags_str) {
+            uint64_t unverified_flags = strtoull(unverified_flags_str, &endptr, 0);
+            if ((unverified_flags == ULLONG_MAX && errno != 0) || *endptr != '\0')
+                ERR_RETURN("error parsing partition %d's flags", partition_ix);
+            flags = unverified_flags;
+        }
+
+        // Boot for GPT partitions means bit 2 of the attribute flags is set.
+        if (cfg_getbool(partition, "boot")) {
+            flags |= 0x4;
+
+            // Support for "boot" was not added until after 1.6.0. To support
+            // older versions of fwup, update the "flags" field with the bit
+            // on.
+            char new_flags_str[32];
+            sprintf(new_flags_str, "0x%" PRIx64, flags);
+            cfg_setstr(partition, "flags", new_flags_str);
+            cfg_setbool(partition, "boot", cfg_false);
+        }
+
         partitions[partition_ix].flags = flags;
         partitions[partition_ix].valid = true;
     }

--- a/src/progress.c
+++ b/src/progress.c
@@ -73,7 +73,7 @@ static void draw_progress_bar(struct fwup_progress *progress, int percent)
     } else {
         off_t read_units = find_natural_units(progress->input_bytes);
         off_t written_units = find_natural_units(progress->current_units);
-        printf("\r%3d%% [%-" PROGRESS_BITS_STR ".*s] %.2f %s in / %.2f %s out   \b\b\b",
+        printf("\r%3d%% [%-" PROGRESS_BITS_STR ".*s] %.2f %s in / %.2f %s out     \b\b\b\b\b",
                percent,
                percent * PROGRESS_BITS / 100, fifty_equals,
                ((double) progress->input_bytes) / read_units,

--- a/tests/177_gpt_boot_flag-generate.sh
+++ b/tests/177_gpt_boot_flag-generate.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+set -e
+
+# Adapted from Buildroot
+
+# GPT partition type UUIDs
+esp_type=c12a7328-f81f-11d2-ba4b-00a0c93ec93b
+linux_type=44479540-f297-41b2-9af7-d131d5f0458a
+
+# Hardcode UUIDs for reproducible images (call uuidgen to make more)
+disk_uuid=b443fbeb-2c93-481b-88b3-0ecb0aeba911
+efi_part_uuid=5278721d-0089-4768-85df-b8f1b97e6684
+root_part_uuid=fcc205c8-2f1c-4dcd-bef4-7b209aa15cca
+
+# Boot partition offset and size, in 512-byte sectors
+efi_part_start=64
+efi_part_size=32768
+
+# Rootfs partition offset and size, in 512-byte sectors
+root_part_start=$(( efi_part_start + efi_part_size ))
+root_part_size=65536
+
+gpt_size=33
+
+first_lba=$(( 1 + gpt_size ))
+last_lba=$(( root_part_start + root_part_size ))
+
+# Disk image size in 512-byte sectors
+image_size=$(( last_lba + gpt_size + 1 ))
+
+primary_gpt_lba=0
+secondary_gpt_lba=$(( image_size - gpt_size ))
+
+rm -f disk.img disk-primary-gpt.img disk-secondary-gpt.img
+dd if=/dev/zero of=disk.img bs=512 count=0 seek=$image_size 2>/dev/null
+
+sfdisk disk.img <<EOF
+label: gpt
+label-id: $disk_uuid
+device: /dev/foobar0
+unit: sectors
+first-lba: $first_lba
+last-lba: $last_lba
+
+/dev/foobar0p1 : start=$efi_part_start,  size=$efi_part_size,  type=$esp_type,   uuid=$efi_part_uuid,  name="efi-part.vfat", attrs=LegacyBIOSBootable
+/dev/foobar0p2 : start=$root_part_start, size=$root_part_size, type=$linux_type, uuid=$root_part_uuid, name="rootfs.ext2", attrs="LegacyBIOSBootable,50,51"
+EOF
+
+echo
+echo "Add the following to the unit test"
+echo
+echo "base64_decodez >\$WORK/expected-primary-gpt.img <<EOF"
+dd if=disk.img bs=512 count=$gpt_size skip=$primary_gpt_lba 2>/dev/null | gzip -c | base64
+echo "EOF"
+echo "base64_decodez >\$WORK/expected-secondary-gpt.img <<EOF"
+dd if=disk.img bs=512 count=$gpt_size skip=$secondary_gpt_lba 2>/dev/null | gzip -c | base64
+echo "EOF"
+echo "cp \$WORK/expected-primary-gpt.img \$WORK/expected.img"
+echo "dd if=\$WORK/expected-secondary-gpt.img of=\$WORK/expected.img bs=512 seek=$secondary_gpt_lba conv=notrunc"
+
+

--- a/tests/177_gpt_boot_flag.test
+++ b/tests/177_gpt_boot_flag.test
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+#
+# Test that "boot = true" sets bit 2 of the flags
+# This tests both using "boot = true" in isolation and with "flags = x"
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+define(EFI_TYPE, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b")
+define(LINUX_TYPE, "44479540-f297-41b2-9af7-d131d5f0458a")
+
+define(DISK_UUID, "b443fbeb-2c93-481b-88b3-0ecb0aeba911")
+define(EFI_PART_UUID, "5278721d-0089-4768-85df-b8f1b97e6684")
+define(ROOTFS_PART_UUID, "fcc205c8-2f1c-4dcd-bef4-7b209aa15cca")
+
+define(EFI_PART_OFFSET, 64)
+define(EFI_PART_COUNT, 32768)
+define-eval(ROOTFS_PART_OFFSET, "\${EFI_PART_OFFSET} + \${EFI_PART_COUNT}")
+define(ROOTFS_PART_COUNT, 65536)
+
+gpt gpt-a {
+    guid = \${DISK_UUID}
+
+    partition 0 {
+        block-offset = \${EFI_PART_OFFSET}
+        block-count = \${EFI_PART_COUNT}
+        type = \${EFI_TYPE}
+        guid = \${EFI_PART_UUID}
+        name = "efi-part.vfat"
+        boot = true
+    }
+    partition 1 {
+        block-offset = \${ROOTFS_PART_OFFSET}
+        block-count = \${ROOTFS_PART_COUNT}
+        type = \${LINUX_TYPE}
+        guid = \${ROOTFS_PART_UUID}
+        name = "rootfs.ext2"
+        boot = true
+        flags = 0xc000000000000
+    }
+}
+task complete {
+	on-init {
+                gpt_write(gpt-a)
+        }
+}
+EOF
+
+# Create the expected output from sfdisk by running ./177_gpt_boot_flag-generate.sh on
+# Linux.
+base64_decodez >$WORK/expected-primary-gpt.img <<EOF
+H4sIAAAAAAAAA+3QwSuDcRzH8e+z5iKpnZHlJA1xVTyL2SSlxW0Hz2FPnGhbWkTPgcJVWs3Fjhxt
+B3ZQczJyoJz9ASshRVGPn/yect0OpN6vX0/P9/v7/Z7fp98jgv/MJw+u6xqqshyj7q9njyLjE8Hp
+cHxGxJCEmilUVta+VryzvFO7dG/qvvY+WtoNtcW2iq1XzbXDgE+vO/qx54r7jd0Iv6k73VPpfLsN
+lCfloDpcHepIZePbMh/dvD95Ol23N0y9b8T5fvt1nxRbFqRXlsSSlGSkT5bVjKWq+ph70bHc83E4
+/3ozcPcY2bloOv9o77+eOntZDeYLiUvT8fKNH/ktKnNRjYzKTKvspGRVPdj4bwAAAAAAAAAAAAAA
+AAAAAAAAAAAAAACAP/cJQQaM2gBCAAA=
+EOF
+base64_decodez >$WORK/expected-secondary-gpt.img <<EOF
+H4sIAAAAAAAAA+3bsUtCURTH8fOglohAaLNImiJKsTXI9yiziCCk0aE3+LApUQkhiDcUVGtEYEuN
+rdlQDkJNWTgUNIuzi4qQUIM3vEGrDeHw/Vwu59zDhR/3D7hT6emHifabp7Aml6WF0vx4Khs9lkTk
+sHLXuN93DkzpCrndOqDPcXFkW2YlKbakJCN+2VUTW3W9Mc8iS+fNGyv38Rp8r4dPngYfv8YC5fVi
+a8+Xu4o9m+5PvvErf1hl7qiVUZlplR2XrOrneswGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKBfhJdX
+fRtWdFPEkJg6G6PV9vfc1v/tDX1vUldTz2ufi7enM96Vo/zIy1Dt2mPpuau3s5W/+K834O86+NTZ
+EABCAAA=
+EOF
+cp $WORK/expected-primary-gpt.img $WORK/expected.img
+dd if=$WORK/expected-secondary-gpt.img of=$WORK/expected.img bs=512 seek=98369 conv=notrunc
+
+# Create the firmware file, then "burn it"
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+$FWUP_APPLY -a -d $IMGFILE -i $FWFILE -t complete
+
+# The firmware file is equivalent to the following dd call
+cmp_bytes 50381824 $WORK/expected.img $IMGFILE
+
+# Check that the verify logic works on this file
+$FWUP_VERIFY -V -i $FWFILE

--- a/tests/178_gpt_bad_flags.test
+++ b/tests/178_gpt_bad_flags.test
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+#
+# Test that an invalidate flags field in the GPT header errors out.
+#
+
+. "$(cd "$(dirname "$0")" && pwd)/common.sh"
+
+cat >$CONFIG <<EOF
+define(EFI_TYPE, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b")
+define(LINUX_TYPE, "44479540-f297-41b2-9af7-d131d5f0458a")
+
+define(DISK_UUID, "b443fbeb-2c93-481b-88b3-0ecb0aeba911")
+define(EFI_PART_UUID, "5278721d-0089-4768-85df-b8f1b97e6684")
+define(ROOTFS_PART_UUID, "fcc205c8-2f1c-4dcd-bef4-7b209aa15cca")
+
+define(EFI_PART_OFFSET, 64)
+define(EFI_PART_COUNT, 32768)
+define-eval(ROOTFS_PART_OFFSET, "\${EFI_PART_OFFSET} + \${EFI_PART_COUNT}")
+define(ROOTFS_PART_COUNT, 65536)
+
+gpt gpt-a {
+    guid = \${DISK_UUID}
+
+    partition 0 {
+        block-offset = \${EFI_PART_OFFSET}
+        block-count = \${EFI_PART_COUNT}
+        type = \${EFI_TYPE}
+        guid = \${EFI_PART_UUID}
+        flags = nono
+    }
+}
+task complete {
+	on-init {
+                gpt_write(gpt-a)
+        }
+}
+EOF
+
+if $FWUP_CREATE -c -f $CONFIG -o $FWFILE; then
+    echo "Expected fwup to detect the bad gpt flags field."
+fi
+

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -41,18 +41,18 @@ TESTS = 001_simple_fw.test \
 	024_metadata_sig.test \
 	025_bad_sig.test \
 	026_sign_again.test \
-        027_fat_timestamp.test \
-        028_osip.test \
+	027_fat_timestamp.test \
+	028_osip.test \
 	029_5G_offset.test \
 	030_2T_offset.test \
 	031_fat_mkfs_5G.test \
 	032_fat_2T_offset.test \
 	033_bad_host_path.test \
-        034_missing_host_path.test \
-        035_streaming.test \
-        036_streaming_signed_fw.test \
-        037_streaming_bad_sig.test \
-        038_write_15M.test \
+	034_missing_host_path.test \
+	035_streaming.test \
+	036_streaming_signed_fw.test \
+	037_streaming_bad_sig.test \
+	038_write_15M.test \
 	039_upgrade.test \
 	041_version.test \
 	042_fat_am335x.test \
@@ -158,7 +158,7 @@ TESTS = 001_simple_fw.test \
 	142_file_resource_size.test \
 	143_include_path.test \
 	144_require_version.test \
-        145_require_path_at_offset.test \
+	145_require_path_at_offset.test \
 	146_deploy_variables.test \
 	147_multiple_keys.test \
 	148_config_from_stdin.test \
@@ -189,6 +189,8 @@ TESTS = 001_simple_fw.test \
 	173_bad_delta_upgrades.test \
 	174_streamed_delta_upgrade.test \
 	175_sign_delta_upgrade.test \
-	176_newline_in_key.test
+	176_newline_in_key.test \
+	177_gpt_boot_flag.test \
+	178_gpt_bad_flags.test
 
 EXTRA_DIST = $(TESTS) common.sh 1K.bin 1K-corrupt.bin 150K.bin


### PR DESCRIPTION
Now instead of `flags=0x4`, you can specify `boot=true`. To ensure that older versions of fwup will still work with new files, if `boot=true`, the `flags` field is updated when stored in the `.fw` file.

Fixes #132 