### PR TITLE
Mark skipped tests in results

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,7 +113,7 @@ AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion_dir" != "x
 
 # Ptrace checks in regression tests
 AM_CONDITIONAL([IS_CROSSCOMPILING], [test x$cross_compiling = x"yes"])
-AM_CONDITIONAL([HAS_VERIFY_SYSCALLS], [test x$host = x"x86_64-pc-linux-gnu"])
+AM_CONDITIONAL([HAS_VERIFY_SYSCALLS], [test x$host = x"x86_64-pc-linux-gnu" -o x$host = x"x86_64-unknown-linux-gnu"])
 
 # Scripts
 AC_ARG_ENABLE(scripts,[AS_HELP_STRING([--disable-scripts], [do not install img2fwup and any other helper scripts])])

--- a/tests/029_5G_offset.test
+++ b/tests/029_5G_offset.test
@@ -13,7 +13,7 @@
 # at least 1 MB hole size support)
 if ! $FWUP_CREATE --sparse-check "$WORK/sparse.bin" --sparse-check-size 0x100000; then
     echo "Skipping test since OS or filesystem lacks sparse file support"
-    exit 0
+    exit 77
 fi
 
 cat >$CONFIG <<EOF

--- a/tests/030_2T_offset.test
+++ b/tests/030_2T_offset.test
@@ -13,7 +13,7 @@ case $HOST_ARCH in
     arm*)
         # Raspberry Pi and likely other 32-bit ARMs error out
 	# on large files.
-        exit 0
+        exit 77
         ;;
     *)
         ;;
@@ -23,7 +23,7 @@ esac
 # at least 1 MB hole size support)
 if ! $FWUP_CREATE --sparse-check "$WORK/sparse.bin" --sparse-check-size 0x100000; then
     echo "Skipping test since OS or filesystem lacks sparse file support"
-    exit 0
+    exit 77
 fi
 
 cat >$CONFIG <<EOF

--- a/tests/031_fat_mkfs_5G.test
+++ b/tests/031_fat_mkfs_5G.test
@@ -11,7 +11,7 @@
 # at least 1 MB hole size support)
 if ! $FWUP_CREATE --sparse-check "$WORK/sparse.bin" --sparse-check-size 0x100000; then
     echo "Skipping test since OS or filesystem lacks sparse file support"
-    exit 0
+    exit 77
 fi
 
 cat >$CONFIG <<EOF

--- a/tests/032_fat_2T_offset.test
+++ b/tests/032_fat_2T_offset.test
@@ -12,7 +12,7 @@ case $HOST_ARCH in
     arm*)
         # Raspberry Pi and likely other 32-bit ARMs error out
 	# on large files.
-        exit 0
+        exit 77
         ;;
     *)
         ;;
@@ -22,7 +22,7 @@ esac
 # at least 1 MB hole size support)
 if ! $FWUP_CREATE --sparse-check "$WORK/sparse.bin" --sparse-check-size 0x100000; then
     echo "Skipping test since OS or filesystem lacks sparse file support"
-    exit 0
+    exit 77
 fi
 
 cat >$CONFIG <<EOF

--- a/tests/090_sparse_write.test
+++ b/tests/090_sparse_write.test
@@ -15,7 +15,7 @@ SPARSE_FILE=$WORK/sparse.bin
 
 if ! $FWUP_CREATE --sparse-check "$SPARSE_FILE" --sparse-check-size 4096; then
     echo "Skipping sparse file tests since OS or filesystem lacks support"
-    exit 0
+    exit 77
 fi
 
 TESTFILE_4K=$WORK/4k.bin

--- a/tests/091_sparse_write2.test
+++ b/tests/091_sparse_write2.test
@@ -15,12 +15,12 @@ SPARSE_FILE=$WORK/sparse.bin
 
 if ! $FWUP_CREATE --sparse-check "$SPARSE_FILE" --sparse-check-size 4096; then
     echo "Skipping sparse file tests since OS or filesystem lacks support"
-    exit 0
+    exit 77
 fi
 
 if [ "$HOST_OS" = "Darwin" ]; then
     echo "Skipping test on APFS since hole creation varies between runs."
-    exit 0
+    exit 77
 fi
 
 TESTFILE_4K=$WORK/4k.bin

--- a/tests/092_sparse_write3.test
+++ b/tests/092_sparse_write3.test
@@ -17,12 +17,12 @@ SPARSE_FILE=$WORK/sparse.bin
 
 if ! $FWUP_CREATE --sparse-check "$SPARSE_FILE" --sparse-check-size 4096; then
     echo "Skipping sparse file tests since OS or filesystem lacks support"
-    exit 0
+    exit 77
 fi
 
 if [ "$HOST_OS" = "Darwin" ]; then
     echo "Skipping test on APFS since hole creation varies between runs."
-    exit 0
+    exit 77
 fi
 
 TESTFILE_4K=$WORK/4k.bin

--- a/tests/093_sparse_concat.test
+++ b/tests/093_sparse_concat.test
@@ -15,12 +15,12 @@ SPARSE_FILE=$WORK/sparse.bin
 
 if ! $FWUP_CREATE --sparse-check "$SPARSE_FILE" --sparse-check-size 4096; then
     echo "Skipping sparse file tests since OS or filesystem lacks support"
-    exit 0
+    exit 77
 fi
 
 if [ "$HOST_OS" = "Darwin" ]; then
     echo "Skipping test on APFS since hole creation varies between runs."
-    exit 0
+    exit 77
 fi
 
 TESTFILE_4K=$WORK/4k.bin

--- a/tests/094_sparse_concat2.test
+++ b/tests/094_sparse_concat2.test
@@ -21,12 +21,12 @@ SPARSE_FILE=$WORK/sparse.bin
 
 if ! $FWUP_CREATE --sparse-check "$SPARSE_FILE" --sparse-check-size 4096; then
     echo "Skipping sparse file tests since OS or filesystem lacks support"
-    exit 0
+    exit 77
 fi
 
 if [ "$HOST_OS" = "Darwin" ]; then
     echo "Skipping test on APFS since hole creation varies between runs."
-    exit 0
+    exit 77
 fi
 
 TESTFILE_4K=$WORK/4k.bin

--- a/tests/105_require_path_on_device.test
+++ b/tests/105_require_path_on_device.test
@@ -12,11 +12,11 @@ case $HOST_OS in
     Darwin|Windows)
         # require-path-on-device not implemented due to not
 	# expecting it to be needed.
-        exit 0
+        exit 77
         ;;
     FreeBSD|NetBSD|OpenBSD|DragonFly)
         # find_rdev doesn't work due to stat calls.
-        exit 0
+        exit 77
         ;;
     *)
         ;;
@@ -25,7 +25,7 @@ esac
 if [ "$CC" = "x86_64-w64-mingw32-gcc" -o "$MODE" = "windows" ]; then
     # Try to detect the cross-compile for Windows case since
     # this really doesn't make sense for this test.
-    exit 0
+    exit 77
 fi
 
 # Figure out where the root filesystem is. Sadly, we can't
@@ -45,7 +45,7 @@ find_rdev() {
 RDEV=$(find_rdev)
 if [ -z $RDEV ]; then
     echo "The root filesystem doesn't map to one device file, so can't test for rdev"
-    exit 0
+    exit 77
 fi
 
 cat >$CONFIG <<EOF

--- a/tests/111_streaming_exit_fast.test
+++ b/tests/111_streaming_exit_fast.test
@@ -11,7 +11,7 @@
 
 if [ -z $TIMEOUT ]; then
     echo "GNU coreutils' timeout command unavailable so skipping test."
-    exit 0
+    exit 77
 fi
 
 cat >$CONFIG <<EOF

--- a/tests/130_media_sizes.test
+++ b/tests/130_media_sizes.test
@@ -13,7 +13,7 @@
 # sparse file support.
 if ! $FWUP_CREATE --sparse-check "$IMGFILE" --sparse-check-size 4096; then
     echo "Skipping media size tests since OS or filesystem lacks sparse file support"
-    exit 0
+    exit 77
 fi
 
 cat >$CONFIG <<EOF

--- a/tests/134_pipe_write_file.test
+++ b/tests/134_pipe_write_file.test
@@ -12,7 +12,7 @@ OUTFILE=$WORK/output1k
 if [ "$CC" = "x86_64-w64-mingw32-gcc" -o "$MODE" = "windows" ]; then
     # This test needs a Windows executable that reads from STDIN.
     # No suitable executables are currently on Travis CI Image
-    exit 0
+    exit 77
 fi
 
 cat >$CONFIG <<EOF

--- a/tests/145_require_path_at_offset.test
+++ b/tests/145_require_path_at_offset.test
@@ -12,11 +12,11 @@ case $HOST_OS in
     Darwin|Windows)
         # require-path-on-device not implemented due to not
 	# expecting it to be needed.
-        exit 0
+        exit 77
         ;;
     FreeBSD|NetBSD|OpenBSD|DragonFly)
         # find_rdev doesn't work due to stat calls.
-        exit 0
+        exit 77
         ;;
     *)
         ;;
@@ -25,7 +25,7 @@ esac
 if [ "$CC" = "x86_64-w64-mingw32-gcc" -o "$MODE" = "windows" ]; then
     # Try to detect the cross-compile for Windows case since
     # this really doesn't make sense for this test.
-    exit 0
+    exit 77
 fi
 
 # Figure out where the root filesystem is. Sadly, we can't
@@ -45,7 +45,7 @@ find_rdev() {
 RDEV=$(find_rdev)
 if [ -z $RDEV ]; then
     echo "The root filesystem doesn't map to one device file, so can't test for rdev"
-    exit 0
+    exit 77
 fi
 
 # Get the major and minor number in decimal
@@ -55,7 +55,7 @@ RDEV_MINOR=$(printf "%d" 0x$(stat $RDEV -c "%T"))
 RDEV_START_FILE=/sys/dev/block/$RDEV_MAJOR:$RDEV_MINOR/start
 if [ ! -e "$RDEV_START_FILE" ]; then
     echo "Couldn't open $RDEV_START_FILE so likely non-trivial rootfs. Skipping test"
-    exit 0
+    exit 77
 fi
 
 # Get the start block offset

--- a/tests/150_no_sparse.test
+++ b/tests/150_no_sparse.test
@@ -16,7 +16,7 @@ SPARSE_FILE=$WORK/sparse.bin
 
 if ! $FWUP_CREATE --sparse-check "$SPARSE_FILE" --sparse-check-size 4096; then
     echo "Skipping sparse file tests since OS or filesystem lacks support"
-    exit 0
+    exit 77
 fi
 
 TESTFILE_4K=$WORK/4k.bin


### PR DESCRIPTION
It turns out that 77 is the magic exit code to indicate this.