### PR TITLE
Autodetect 128 GiB SDCards

### DIFF
--- a/src/fwup.c
+++ b/src/fwup.c
@@ -313,7 +313,8 @@ static void autoselect_mmc_device(struct mmc_device *device)
         for (int i = 0; i < found_devices; i++) {
             char sizestr[16];
             format_pretty_auto(devices[i].size, sizestr, sizeof(sizestr));
-            fprintf(stderr, "  %s (%s)\n", devices[i].path, sizestr);
+            bool print_name = (devices[i].name[0] != '\0');
+            fprintf(stderr, "  %s (%s%s%s)\n", devices[i].path, sizestr, print_name ? "; " : "", print_name ? devices[i].name : "");
         }
         fprintf(stderr, "Automatic selection not possible. Specify one using the -d option.\n");
         fwup_exit(EXIT_FAILURE);

--- a/src/mmc.h
+++ b/src/mmc.h
@@ -22,10 +22,12 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#define MMC_DEVICE_NAME_LEN 64
 #define MMC_DEVICE_PATH_LEN 64
 #define MMC_MAX_DEVICES 16
 
 struct mmc_device {
+    char name[MMC_DEVICE_NAME_LEN];
     char path[MMC_DEVICE_PATH_LEN];
     off_t size;
 };

--- a/src/mmc.h
+++ b/src/mmc.h
@@ -22,9 +22,16 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#include "util.h"
+
 #define MMC_DEVICE_NAME_LEN 64
 #define MMC_DEVICE_PATH_LEN 64
 #define MMC_MAX_DEVICES 16
+
+// NOTE: The rationale for this check is that the user's main drives will be
+//       large capacity and we don't want to autodetect them when looking for
+//       SDCards.
+#define MMC_MAX_AUTODETECTED_SIZE (129 * ONE_GiB)
 
 struct mmc_device {
     char name[MMC_DEVICE_NAME_LEN];

--- a/src/mmc_bsd.c
+++ b/src/mmc_bsd.c
@@ -121,6 +121,8 @@ static void mmc_scan_by_pattern(struct mmc_device *devices,
  */
 int mmc_scan_for_devices(struct mmc_device *devices, int max_devices)
 {
+    memset(devices, 0, max_devices * sizeof(struct mmc_device));
+
     // Get the root device so that we can filter
     // it's drive out of the autodetected list
     struct stat rootdev;

--- a/src/mmc_bsd.c
+++ b/src/mmc_bsd.c
@@ -63,7 +63,7 @@ static bool mmc_get_device_stats(const char *devpath_pattern,
     return true;
 }
 
-static bool is_autodetectable_mmc_device(const struct mmc_device_info *info, 
+static bool is_autodetectable_mmc_device(const struct mmc_device_info *info,
                                          const struct stat *rootdev)
 {
     // Check 1: Not on the device containing the root fs
@@ -80,11 +80,8 @@ static bool is_autodetectable_mmc_device(const struct mmc_device_info *info,
     if (info->device_size <= 0)
         return false;
 
-    // Check 3: Capacity larger than 65 GiB -> false
-    // NOTE: The rationale for this check is that the user's main drives will be
-    //       large capacity and we don't want to autodetect them when looking for
-    //       SDCards.
-    if (info->device_size > (65 * ONE_GiB))
+    // Check 3: Capacity larger than max autodetectable size -> false
+    if (info->device_size > MMC_MAX_AUTODETECTED_SIZE)
         return false;
 
     return true;

--- a/src/mmc_linux.c
+++ b/src/mmc_linux.c
@@ -188,6 +188,8 @@ static dev_t root_disk_device()
 
 int mmc_scan_for_devices(struct mmc_device *devices, int max_devices)
 {
+    memset(devices, 0, max_devices * sizeof(struct mmc_device));
+
     enumerate_mmc_devices();
 
     // Get the root device so that we can filter

--- a/src/mmc_osx.c
+++ b/src/mmc_osx.c
@@ -104,9 +104,9 @@ static void scan_disk_appeared_cb(DADiskRef disk, void *c)
 
         CFRelease(info);
 
-        // Filter out large devices (> 65 GiB) since those are probably backup drives
+        // Filter out large devices since those are probably backup drives
         // and not SDCards.
-        if (size > (65 * ONE_GiB))
+        if (size > MMC_MAX_AUTODETECTED_SIZE)
             return;
 
         context->count++;

--- a/src/mmc_osx.c
+++ b/src/mmc_osx.c
@@ -100,10 +100,6 @@ static void scan_disk_appeared_cb(DADiskRef disk, void *c)
         context->devices[ix].size = size;
         CFRelease(info);
 
-        // Filter out small devices (< 128M) since those are mounted .dmg files
-        if (size < 128000000)
-            return;
-
         // Filter out large devices (> 65 GiB) since those are probably backup drives
         // and not SDCards.
         if (size > (65 * ONE_GiB))
@@ -144,6 +140,7 @@ int mmc_scan_for_devices(struct mmc_device *devices, int max_devices)
             CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
     CFDictionaryAddValue(toMatch, kDADiskDescriptionMediaWholeKey, kCFBooleanTrue);
     CFDictionaryAddValue(toMatch, kDADiskDescriptionMediaRemovableKey, kCFBooleanTrue);
+    CFDictionaryAddValue(toMatch, kDADiskDescriptionMediaWritableKey, kCFBooleanTrue);
 
     struct scan_context context;
     context.devices = devices;

--- a/src/mmc_windows.c
+++ b/src/mmc_windows.c
@@ -41,6 +41,8 @@ void mmc_finalize()
  */
 int mmc_scan_for_devices(struct mmc_device *devices, int max_devices)
 {
+    memset(devices, 0, max_devices * sizeof(struct mmc_device));
+
     // There's not an API to request all the PhysicalDrives, but they are
     // sequentially enumerated and become invalid if they're removed.
     // So we just scan the first 256 of them until we find enough matches


### PR DESCRIPTION
These are getting popular, so allow them to be autodetected now.

The downside is that anyone with a 128 GiB drive on a platform where
`fwup` can't detect whether it's nonremovable will have to be more
careful. Hopefully that's not very common among `fwup` users.