### PR TITLE
Only build for windows with Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 
 sudo: required
-dist: focal
+dist: xenial
 
 env:
     global:
@@ -18,6 +18,7 @@ matrix:
         - os: linux
           compiler: gcc
           env: MODE=windows
+          dist: focal
         - os: linux
           compiler: gcc
           env: MODE=minimal


### PR DESCRIPTION
Building with Ubuntu 20.04 ended up creating packages that had minimal
glibc requirements that forced users to update. This wasn't necessary,
so change the default version of Ubuntu back to the way it was before
the Windows updates.