### PR TITLE
Change the URL of the Web site of libconfuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ may not be what you want.
 # Configuration file format
 
 `fwup` uses the Unix configuration library,
-[libconfuse](http://www.nongnu.org/confuse/), so its configuration has some
+[libconfuse](https://github.com/libconfuse/libconfuse), so its configuration has some
 similarities to other programs. The configuration file is used to create
 firmware archives. During creation, `fwup` embeds a processed version of the
 configuration file into the archive that has been stripped of comments, has had


### PR DESCRIPTION
The Web site of libconfuse has moved to https://github.com/libconfuse/libconfuse from https://www.nongnu.org/confuse/ .

![image](https://user-images.githubusercontent.com/3458/103464990-6a9e2f80-4d7b-11eb-967c-0facecc730b8.png)

> The libConfuse project has moved to github. You are being redirected automatically.
[libConfuse](https://www.nongnu.org/confuse/)