### PR TITLE
Add a simple two-word nickname for UUIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ meta-misc            | Miscellaneous additional data. Format and contents are up
 meta-creation-date   | Timestamp when the update was created (derived from ZIP metadata). For reproducible builds, set the [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/#idm55) environment variable.
 meta-fwup-version    | Version of fwup used to create the update (deprecated - no longer added since fwup 1.2.0)
 meta-uuid            | A UUID to represent this firmware. The UUID won't change even if the .fw file is digitally signed after creation (automatically generated)
+meta-nickname        | A nickname generated from the UUID for ease of differentiating firmware files. It is only an aid and is not guaranteed unique
 
 After setting the above options, it is necessary to create scopes for other options. The
 currently available scopes are:
@@ -1213,6 +1214,8 @@ fwup supports several ways:
 2. Store the `git` hash in `meta-vcs-identifier`. This is good for developers.
 3. Use the `fwup`-computed UUID that's available in `meta-uuid' and
    `${FWUP_META_UUID}`.
+4. Use the `fwup`-computed nickname that's available in `meta-nickname` and
+   `${FWUP_META_NICKNAME}`.
 
 Of these, the third one is always available since version fwup `v1.2.1`. The
 motivation behind it was to unambiguously know whether installed firmware
@@ -1222,6 +1225,13 @@ previous versions of fwup have UUIDs.
 The first two options require the versions to be added to the `fwup.conf` file.
 They are usually added using environment variables so that the version numbers
 are not hardcoded.
+
+Even though firmware UUIDs are the most reliable way of differentiating firmware
+files and completely automatic, they're hard to remember. The `meta-nickname` is
+intended to help with this by giving the user a couple words to check.
+Unfortunately, it's only derived from 16-bits of the UUID so it's not guaranteed
+unique. This was the compromise to make it human memorable, and it's sufficient
+to reliably notice if a firmware updated or not in development.
 
 ## How do I get the firmware metadata formatted as JSON
 

--- a/src/cfgfile.c
+++ b/src/cfgfile.c
@@ -586,6 +586,7 @@ static cfg_opt_t opts[] = {
     CFG_STR("meta-vcs-identifier", 0, CFGF_NONE),
     CFG_STR("meta-misc", 0, CFGF_NONE),
     CFG_STR("meta-uuid", 0, CFGF_NONE),
+    CFG_STR("meta-nickname", 0, CFGF_NONE),
 
     CFG_STR("require-fwup-version", "0", CFGF_NONE),
     CFG_FUNC("define", cb_define),
@@ -622,6 +623,7 @@ int cfgfile_parse_file(const char *filename, cfg_t **cfg)
     // at "apply" time since it can't be calculated at creation time without
     // affecting itself.
     set_environment("FWUP_META_UUID", "${FWUP_META_UUID}");
+    set_environment("FWUP_META_NICKNAME", "${FWUP_META_NICKNAME}");
 
     // libconfuse 3.0 note: This function is called when creating
     // archives. If there's an unknown option, we want to throw an
@@ -766,17 +768,22 @@ int cfgfile_parse_fw_ae(struct archive *a,
     cfg_setstr(*cfg, "meta-creation-date", str);
 
     // meta-uuid is always calculated and cannot be overriden
-    calculate_fwup_uuid(meta_conf, total_size, str);
+    char nickname[UUID_NICKNAME_LENGTH];
+    calculate_fwup_uuid(meta_conf, total_size, str, nickname);
     cfg_setstr(*cfg, "meta-uuid", str);
+    cfg_setstr(*cfg, "meta-nickname", nickname);
     set_environment("FWUP_META_UUID", str);
+    set_environment("FWUP_META_NICKNAME", nickname);
 
     if (cfg_parse_buf(*cfg, meta_conf) != 0)
         ERR_CLEANUP_MSG("Unexpected error parsing meta.conf");
 
     // Verify that meta-uuid wasn't changed when loading the file.
     if (strcmp(str, cfg_getstr(*cfg, "meta-uuid")) != 0 ||
-        strcmp(str, get_environment("FWUP_META_UUID")) != 0)
-        ERR_CLEANUP_MSG("meta.conf isn't allowed to change 'meta-uuid' or '$FWUP_META_UUID'");
+        strcmp(str, get_environment("FWUP_META_UUID")) != 0 ||
+        strcmp(nickname, cfg_getstr(*cfg, "meta-nickname")) != 0 ||
+        strcmp(nickname, get_environment("FWUP_META_NICKNAME")) != 0)
+        ERR_CLEANUP_MSG("meta.conf isn't allowed to change 'meta-uuid', 'meta-nickname', '$FWUP_META_UUID' or '$FWUP_META_NICKNAME'");
 
 cleanup:
     if (meta_conf)

--- a/src/cfgprint.c
+++ b/src/cfgprint.c
@@ -230,8 +230,9 @@ void fwup_cfg_opt_to_string(cfg_opt_t *opt, struct simple_string *s, bool scrub)
                     strcmp("skip-holes", opt->name) == 0)
                     return;
 
-                // Skip attributes not are automatically calculated
+                // Skip attributes that are automatically calculated
                 if (strcmp("meta-uuid", opt->name) == 0 ||
+                    strcmp("meta-nickname", opt->name) == 0 ||
                     strcmp("meta-creation-date", opt->name) == 0)
                     return;
             }

--- a/src/fwup_metadata.c
+++ b/src/fwup_metadata.c
@@ -40,6 +40,7 @@ static void list_metadata(cfg_t *cfg, struct simple_string *s)
     list_one(cfg, "meta-misc", s);
     list_one(cfg, "meta-vcs-identifier", s);
     list_one(cfg, "meta-uuid", s);
+    list_one(cfg, "meta-nickname", s);
 }
 
 /**

--- a/src/util.c
+++ b/src/util.c
@@ -625,6 +625,93 @@ int update_relative_path(const char *fromfile, const char *filename, char **newp
     return 0;
 }
 
+// 256-word word list for computing a word34567
+// This array intentionally has no separators to save memory. See the function below for details.
+static const char *word34567_words = \
+    "act" "able" "about" "absent" "abandon" \
+    "add" "away" "aisle" "advice" "address" \
+    "aim" "best" "anger" "annual" "analyst" \
+    "all" "bone" "armor" "assume" "apology" \
+    "arm" "cake" "beach" "barrel" "average" \
+    "ask" "chat" "bless" "bitter" "bargain" \
+    "bar" "club" "brick" "bronze" "blanket" \
+    "bid" "corn" "cabin" "camera" "capital" \
+    "boy" "dash" "chalk" "casual" "certain" \
+    "can" "dice" "civil" "cherry" "coconut" \
+    "cat" "drip" "cloud" "column" "conduct" \
+    "cup" "east" "craft" "credit" "crucial" \
+    "day" "fall" "curve" "debris" "cushion" \
+    "dry" "fine" "dream" "depend" "despair" \
+    "egg" "foil" "earth" "dinner" "dilemma" \
+    "era" "gain" "entry" "dragon" "dynamic" \
+    "fan" "glad" "exist" "energy" "emotion" \
+    "few" "grit" "field" "estate" "essence" \
+    "fix" "head" "focus" "expire" "exhibit" \
+    "fog" "hood" "gauge" "finger" "fatigue" \
+    "fox" "idea" "glove" "fossil" "forward" \
+    "gap" "jump" "grunt" "garlic" "genuine" \
+    "hat" "kiwi" "hello" "guitar" "gravity" \
+    "hip" "lazy" "inner" "horror" "illness" \
+    "ice" "link" "labor" "indoor" "initial" \
+    "job" "loop" "light" "invest" "jealous" \
+    "key" "math" "maple" "laptop" "lecture" \
+    "kid" "mind" "mimic" "lonely" "lottery" \
+    "lab" "name" "nasty" "margin" "mention" \
+    "mad" "nose" "offer" "middle" "monitor" \
+    "mix" "open" "owner" "motion" "network" \
+    "net" "pass" "piano" "nephew" "observe" \
+    "nut" "plug" "power" "online" "ostrich" \
+    "oak" "pulp" "purse" "palace" "peasant" \
+    "oil" "ramp" "ready" "phrase" "popular" \
+    "one" "ring" "round" "praise" "present" \
+    "pen" "safe" "scrap" "reason" "program" \
+    "pig" "seed" "shock" "relief" "pudding" \
+    "raw" "sign" "skill" "resist" "raccoon" \
+    "rug" "slot" "snack" "ripple" "release" \
+    "run" "soon" "spawn" "salute" "satisfy" \
+    "say" "step" "spray" "select" "session" \
+    "shy" "tape" "still" "silver" "slender" \
+    "spy" "text" "super" "sphere" "stomach" \
+    "tag" "tiny" "table" "street" "supreme" \
+    "tip" "trip" "tired" "symbol" "thunder" \
+    "toe" "undo" "trade" "ticket" "trigger" \
+    "toy" "visa" "truth" "travel" "uncover" \
+    "two" "wasp" "vague" "unfold" "utility" \
+    "van" "wild" "vivid" "valley" "vibrant" \
+    "web" "yard" "zebra" "voyage" "weather" \
+    "zoo" \
+    "";
+
+// Return the word at the specified index
+static void word34567(int index, const char **word, int *len)
+{
+    // Each row has 5 words with lengths 3 to 7. That's 25 letters per row.
+    // The offset of the mth word in each row is 0, 3, 7, 12, 18, but this
+    // can be computed as m * (m + 5) / 2.
+    int m = index % 5;
+    *len = m + 3;
+    *word = &word34567_words[(index / 5) * 25 + m * (m + 5) / 2];
+}
+
+// nickname must be at least 16 characters (7 + 1 hyphen + 7 + 1 null terminator)
+static void uuid_to_nickname(const uint8_t uuid[UUID_LENGTH], char *nickname)
+{
+    const char *word;
+    int len;
+
+    word34567(uuid[0], &word, &len);
+    memcpy(nickname, word, len);
+    nickname += len;
+
+    *nickname++ = '-';
+
+    word34567(uuid[1], &word, &len);
+    memcpy(nickname, word, len);
+    nickname += len;
+
+    *nickname = '\0';
+}
+
 /**
  * Convert a UUID to a string in big endian form.
  *
@@ -686,9 +773,10 @@ int string_to_uuid_me(const char *uuid_str, uint8_t uuid[UUID_LENGTH])
  *
  * @param data
  * @param data_size
- * @param uuid
+ * @param uuid the resulting UUID as a string
+ * @param nickname the resulting nickname
  */
-void calculate_fwup_uuid(const char *data, off_t data_size, char *uuid)
+void calculate_fwup_uuid(const char *data, size_t data_size, char *uuid, char *nickname)
 {
     crypto_blake2b_ctx hash_state;
     crypto_blake2b_general_init(&hash_state, FWUP_BLAKE2b_256_LEN, NULL, 0);
@@ -697,7 +785,7 @@ void calculate_fwup_uuid(const char *data, off_t data_size, char *uuid)
     unsigned char fwup_uuid[UUID_LENGTH] = {0x20, 0x53, 0xdf, 0xfb, 0xd5, 0x1e, 0x43, 0x10, 0xb9, 0x3b, 0x95, 0x6d, 0xa8, 0x9f, 0x9f, 0x34};
 
     crypto_blake2b_update(&hash_state, fwup_uuid, sizeof(fwup_uuid));
-    crypto_blake2b_update(&hash_state, (const unsigned char *) data, (unsigned long long) data_size);
+    crypto_blake2b_update(&hash_state, (const uint8_t *) data, data_size);
 
     unsigned char hash[64];
     crypto_blake2b_final(&hash_state, hash);
@@ -707,6 +795,9 @@ void calculate_fwup_uuid(const char *data, off_t data_size, char *uuid)
     hash[6] = (hash[6] & 0x0f) | 0x50;
 
     uuid_to_string_be(hash, uuid);
+
+    // Since UUIDs are hard to remember, create a convenience nickname
+    uuid_to_nickname(hash, nickname);
 }
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -190,10 +190,11 @@ int update_relative_path(const char *from_file, const char *filename, char **new
 // UUIDs
 #define UUID_LENGTH 16
 #define UUID_STR_LENGTH 37 /* Includes NULL terminator */
+#define UUID_NICKNAME_LENGTH 16 /* Includes NULL terminator */
 
 void uuid_to_string(const uint8_t uuid[UUID_LENGTH], char *uuid_str);
 int string_to_uuid_me(const char *uuid_str, uint8_t uuid[UUID_LENGTH]);
-void calculate_fwup_uuid(const char *data, off_t data_size, char *uuid);
+void calculate_fwup_uuid(const char *data, size_t data_size, char *uuid, char *nickname);
 
 // Endian conversion
 void ascii_to_utf16le(const char *input, char *output, size_t len);

--- a/tests/009_metadata_cmdline.test
+++ b/tests/009_metadata_cmdline.test
@@ -27,6 +27,7 @@ meta-platform="a platform"
 meta-architecture="an architecture"
 meta-creation-date="2018-05-05T18:10:16Z"
 meta-uuid="53233641-82a4-5576-b75d-d227a234c626"
+meta-nickname="energy-bid"
 EOF
 
 # Test the preferred way

--- a/tests/024_metadata_sig.test
+++ b/tests/024_metadata_sig.test
@@ -27,6 +27,7 @@ meta-platform="a platform"
 meta-architecture="an architecture"
 meta-creation-date="2018-05-05T18:10:16Z"
 meta-uuid="53233641-82a4-5576-b75d-d227a234c626"
+meta-nickname="energy-bid"
 EOF
 
 cd $WORK

--- a/tests/054_framed_metadata.test
+++ b/tests/054_framed_metadata.test
@@ -27,6 +27,7 @@ meta-platform="a platform"
 meta-architecture="an architecture"
 meta-creation-date="2018-05-05T18:10:16Z"
 meta-uuid="53233641-82a4-5576-b75d-d227a234c626"
+meta-nickname="energy-bid"
 EOF
 
 cat >$EXPECTED_OUTPUT.type << EOF

--- a/tests/055_metadata_partial_file.test
+++ b/tests/055_metadata_partial_file.test
@@ -34,6 +34,7 @@ meta-platform="a platform"
 meta-architecture="an architecture"
 meta-creation-date="2018-05-05T18:10:16Z"
 meta-uuid="b3c560af-d052-58c1-228d-5fa869817cda"
+meta-nickname="present-snack"
 EOF
 
 SOURCE_DATE_EPOCH=1525543816 $FWUP_CREATE -c -f $CONFIG -o $FWFILE

--- a/tests/061_framed_partial_metadata.test
+++ b/tests/061_framed_partial_metadata.test
@@ -33,6 +33,7 @@ meta-platform="a platform"
 meta-architecture="an architecture"
 meta-creation-date="2018-05-05T18:10:16Z"
 meta-uuid="b3c560af-d052-58c1-228d-5fa869817cda"
+meta-nickname="present-snack"
 EOF
 
 cat >$EXPECTED_OUTPUT.type << EOF

--- a/tests/151_meta_uuid.test
+++ b/tests/151_meta_uuid.test
@@ -27,6 +27,7 @@ meta-platform="a platform"
 meta-architecture="an architecture"
 meta-creation-date="2018-05-05T18:10:16Z"
 meta-uuid="53233641-82a4-5576-b75d-d227a234c626"
+meta-nickname="energy-bid"
 EOF
 
 cd $WORK

--- a/tests/152_meta_vars.test
+++ b/tests/152_meta_vars.test
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 #
-# Test that referencing metadata as variables works. Only FWUP_META_UUID is
-# supported now.
+# Test that referencing FWUP_META_UUID and FWUP_META_NICKNAME as variables works.
 #
 # This test sends variables to a U-Boot environment block. This is a little
 # excessive, but it exercises the same path as some production code.
@@ -14,8 +13,8 @@ EXPECTED_OUTPUT=$WORK/expected_output
 ACTUAL_OUTPUT=$WORK/actual_output
 
 base64_decode >$EXPECTED_OUTPUT <<EOF
-rbt/tHV1aWQ9ZGM0YTQwODEtOWZkNC01MzAyLTZlYjUtZjFlNDk5Y2Q2YTkyAAD/////////////
-////////////////////////////////////////////////////////////////////////////
+ze/Lh25pY2tuYW1lPWFib3V0LWRhc2gAdXVpZD0wMjI5NzZjYi05OWZiLTUzMmUtM2JjOC02NzJj
+NGE5MGNiZDAAAP//////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////
@@ -43,6 +42,7 @@ task complete {
        uboot_clearenv(uboot-env)
 
        uboot_setenv(uboot-env, "uuid", "\\\${FWUP_META_UUID}")
+       uboot_setenv(uboot-env, "nickname", "\\\${FWUP_META_NICKNAME}")
     }
 }
 EOF

--- a/tests/155_friendly_meta_uuid.test
+++ b/tests/155_friendly_meta_uuid.test
@@ -16,13 +16,18 @@ task complete {
     on-finish {
        info("The wrong way to specify the UUID is \${FWUP_META_UUID}, but we'll allow it.")
        info("The right way to specify the UUID is \\\${FWUP_META_UUID}.")
+
+       info("The wrong way to specify the nickname is \${FWUP_META_NICKNAME}, but we'll allow it.")
+       info("The right way to specify the nickname is \\\${FWUP_META_NICKNAME}.")
     }
 }
 EOF
 
 cat >$EXPECTED_OUTPUT <<EOF
-fwup: The wrong way to specify the UUID is 904d5a3b-8973-5bcb-496b-ef02ae8fa5bc, but we'll allow it.
-fwup: The right way to specify the UUID is 904d5a3b-8973-5bcb-496b-ef02ae8fa5bc.
+fwup: The wrong way to specify the UUID is ecb37e6e-6a7b-5f22-2077-7ccad0e40d85, but we'll allow it.
+fwup: The right way to specify the UUID is ecb37e6e-6a7b-5f22-2077-7ccad0e40d85.
+fwup: The wrong way to specify the nickname is visa-present, but we'll allow it.
+fwup: The right way to specify the nickname is visa-present.
 EOF
 
 # Create the firmware file, then apply it

--- a/tests/162_source_date_epoch.test
+++ b/tests/162_source_date_epoch.test
@@ -118,6 +118,7 @@ EOF
 cat >$EXPECTED_METADATA <<EOF
 meta-creation-date="2019-09-19T03:22:13Z"
 meta-uuid="82db9640-3319-5aa6-3c13-195534a8536e"
+meta-nickname="key-stomach"
 EOF
 
 # Create that setting SOURCE_DATE_EPOCH sets the date properly in the archive.


### PR DESCRIPTION
This addresses an issue where different firmware files are mistakenly
thought to be the same despite having different UUIDs. These are almost
always situations where the firmware version numbers weren't bumped
since the firmware was in actively being developed or debugged.

This commit adds the concept of a firmware nickname that's derived from
the UUID. Since it's derived from the UUID, no new metadata is stored.
In fact, the algorithm could be copied out of fwup to avoid the upgrade.

This nickname is two words where the words are chosen from a 256-word
list. That means they only have 16-bits of uniqueness compared to the
124-bits in the UUID. For the intended use case, it should be highly
unlikely for a firmware update to go unnoticed in development when
watching nicknames.

Word list storage is a little more than 1KB, so the feature is a trivial
add to fwup's footprint.
