### PR TITLE
Require --unsafe when applying and not creating

### DIFF
--- a/src/requirement.c
+++ b/src/requirement.c
@@ -204,14 +204,17 @@ int require_execute_validate(struct fun_context *fctx)
     if (fctx->argc != 2)
         ERR_RETURN("require-execute requires a command");
 
-    if (!fwup_unsafe)
-        ERR_RETURN("%s requires --unsafe", fctx->argv[0]);
-
     return 0;
 }
 
 int require_execute_requirement_met(struct fun_context *fctx)
 {
+    // We silently fail here (returning -1) so the system can try the next task
+    // variant. An INFO message will be printed if verbose mode is enabled
+    // showing that the requirement was not met.
+    if (!fwup_unsafe)
+        return -1;
+
     const char *command = fctx->argv[1];
     if (command[0] == '\0')
         return -1;

--- a/tests/220_require_execute.test
+++ b/tests/220_require_execute.test
@@ -15,31 +15,36 @@ fi
 cat >$CONFIG <<EOF
 task upgrade.false {
     require-execute("false")
-    on-init { info("false shouldn't have worked") }
+    on-init { error("false shouldn't have worked") }
 }
 task upgrade.does_not_exist {
     require-execute("/usr/bin/does_not_exist")
-    on-init { info("a non-existent program shouldn't have worked") }
+    on-init { error("a non-existent program shouldn't have worked") }
 }
 task upgrade.empty_string {
     require-execute("")
-    on-init { info("empty string shouldn't succeed") }
+    on-init { error("empty string shouldn't succeed") }
 }
 task upgrade.empty_variable {
     require-execute("\${EMPTY_VAR}")
-    on-init { info("empty variable shouldn't succeed") }
+    on-init { error("empty variable shouldn't succeed") }
 }
 task upgrade.true {
     require-execute("true")
     on-init { info("correct") }
 }
 task upgrade.catchall {
-    on-init { info("catchall triggered and shouldn't have") }
+    on-init { error("catchall triggered and shouldn't have. No --unsafe?") }
 }
 EOF
 
-# Create the firmware file the normal way
-$FWUP_CREATE --unsafe -c -f $CONFIG -o $FWFILE
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Make sure that applying without --unsafe doesn't work
+if $FWUP_APPLY -a -q -d $IMGFILE -i $FWFILE -t upgrade; then
+    echo "Applying without --unsafe should have failed"
+    exit 1
+fi
 
 $FWUP_APPLY --unsafe -a -q -d $IMGFILE -i $FWFILE -t upgrade > $WORK/actual_output.txt
 cat >$WORK/expected_output.txt <<EOF

--- a/tests/221_require_execute_shell_test.test
+++ b/tests/221_require_execute_shell_test.test
@@ -15,27 +15,33 @@ fi
 cat >$CONFIG <<EOF
 task upgrade.wrong-string-match {
     require-execute("[ $(echo bar) = 'foo' ]")
-    on-init { info("bar doesn't = foo") }
+    on-init { error("bar doesn't = foo") }
 }
 task upgrade.wrong-string-match-backticks {
     require-execute("[ `echo bar` = 'foo' ]")
-    on-init { info("bar doesn't = foo") }
+    on-init { error("bar doesn't = foo") }
 }
 task upgrade.wrong-prefix {
     require-execute("[ $(echo bar2) = 'bar' ]")
-    on-init { info("bar2 doesn't = bar") }
+    on-init { error("bar2 doesn't = bar") }
 }
 task upgrade.correct {
     require-execute("[ $(echo bar) = 'bar' ]")
     on-init { info("correct") }
 }
 task upgrade.catchall {
-    on-init { info("catchall shouldn't run") }
+    on-init { error("catchall shouldn't run") }
 }
 EOF
 
 # Create the firmware file the normal way
-$FWUP_CREATE --unsafe -c -f $CONFIG -o $FWFILE
+$FWUP_CREATE -c -f $CONFIG -o $FWFILE
+
+# Check that applying without --unsafe fails
+if $FWUP_APPLY -a -q -d $IMGFILE -i $FWFILE -t upgrade; then
+    echo "Applying without --unsafe should have failed"
+    exit 1
+fi
 
 $FWUP_APPLY --unsafe -a -q -d $IMGFILE -i $FWFILE -t upgrade > $WORK/actual_output.txt
 cat >$WORK/expected_output.txt <<EOF


### PR DESCRIPTION
This fixes an issue where `--unsafe` was only checked at firmware
creation time for `require-execute`. This moves the check to the apply
phase where there actually is an unsafe operation happening.

This also changes many info messages to errors to make doubly sure that
things fail if code paths that should run get invoked.
