### PR TITLE
Use `http://zlib.net/fossils/` for downloading zlib

### DIFF
--- a/scripts/download_deps.sh
+++ b/scripts/download_deps.sh
@@ -27,7 +27,7 @@ mkdir -p $DOWNLOAD_DIR
 echo "Downloading third party libraries to $DOWNLOAD_DIR..."
 
 cd $DOWNLOAD_DIR
-[ -e zlib-$ZLIB_VERSION.tar.gz ] || curl -LO http://zlib.net/zlib-$ZLIB_VERSION.tar.gz
+[ -e zlib-$ZLIB_VERSION.tar.gz ] || curl -LO http://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz
 [ -e confuse-$CONFUSE_VERSION.tar.gz ] || curl -LO https://github.com/martinh/libconfuse/releases/download/v$CONFUSE_VERSION/confuse-$CONFUSE_VERSION.tar.gz
 [ -e libarchive-$LIBARCHIVE_VERSION.tar.gz ] || curl -LO https://libarchive.org/downloads/libarchive-$LIBARCHIVE_VERSION.tar.gz
 


### PR DESCRIPTION
Zlib has released a new version, but this means the current download path is broken as only the newest version is available on that path.

Switching to `http://zlib.net/fossils/*` looks to be a safer download path as it works for previous and the most current release.