### PR TITLE
Use https://zlib.net/fossils for downloading zlib

### DIFF
--- a/scripts/download_deps.sh
+++ b/scripts/download_deps.sh
@@ -27,10 +27,9 @@ mkdir -p $DOWNLOAD_DIR
 echo "Downloading third party libraries to $DOWNLOAD_DIR..."
 
 cd $DOWNLOAD_DIR
-[ -e zlib-$ZLIB_VERSION.tar.gz ] || curl -LO http://zlib.net/zlib-$ZLIB_VERSION.tar.gz
+[ -e zlib-$ZLIB_VERSION.tar.gz ] || curl -LO https://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz
 [ -e confuse-$CONFUSE_VERSION.tar.gz ] || curl -LO https://github.com/martinh/libconfuse/releases/download/v$CONFUSE_VERSION/confuse-$CONFUSE_VERSION.tar.gz
 [ -e libarchive-$LIBARCHIVE_VERSION.tar.gz ] || curl -LO https://libarchive.org/downloads/libarchive-$LIBARCHIVE_VERSION.tar.gz
 
 echo "Verifying checksums..."
 $SHA256SUM -c $BASE_DIR/scripts/third_party.sha256
-


### PR DESCRIPTION
Zlib has released a new version, which means the current download path is broken because only the latest version is available there.

Switching to https://zlib.net/fossils/* appears to be a safer download path, as it works for both the previous and the latest release.
