### PR TITLE
Cache decrypted data to eliminate redundant decryption

### DIFF
--- a/src/block_cache.c
+++ b/src/block_cache.c
@@ -206,6 +206,12 @@ static int read_segment(struct block_cache *bc, struct block_cache_segment *seg,
             // and don't fail.
             memset((uint8_t *) data + bytes_read, 0, BLOCK_CACHE_SEGMENT_SIZE - bytes_read);
         }
+        
+        // Decrypt data after reading from disk if callback is set
+        // This ensures cache holds decrypted data, avoiding redundant decryption on cache hits
+        if (bc->decrypt_callback) {
+            bc->decrypt_callback(bc->decrypt_cookie, data, count, seg->offset);
+        }
     }
     return 0;
 }
@@ -439,6 +445,8 @@ int block_cache_init(struct block_cache *bc,
     bc->hw_trim_enabled = enable_trim;
     bc->end_offset = end_offset;
     bc->is_soft_end_offset = is_soft_end_offset;
+    bc->decrypt_callback = NULL;
+    bc->decrypt_cookie = NULL;
 
     // Set the trim points based on the file size
     if (!is_soft_end_offset && end_offset > 0) {
@@ -459,6 +467,24 @@ int block_cache_init(struct block_cache *bc,
 #endif
 
     return 0;
+}
+
+/**
+ * @brief Set decrypt callback for reading encrypted disks
+ * 
+ * When set, data will be decrypted once when loaded from disk into cache.
+ * This eliminates redundant decryption on cache hits.
+ * 
+ * @param bc block cache
+ * @param decrypt_callback function to decrypt data in-place
+ * @param cookie context pointer passed to decrypt_callback
+ */
+void block_cache_set_decrypt(struct block_cache *bc, 
+                            void (*decrypt_callback)(void *, void *, size_t, off_t),
+                            void *cookie)
+{
+    bc->decrypt_callback = decrypt_callback;
+    bc->decrypt_cookie = cookie;
 }
 
 static int lrucompare(const void *pa, const void *pb)

--- a/src/block_cache.h
+++ b/src/block_cache.h
@@ -97,6 +97,11 @@ struct block_cache {
     off_t end_offset;
     bool is_soft_end_offset; // true if it's ok to write past end_offset (e.g., regular file)
 
+    // Optional decrypt callback for encrypted source disks
+    // Called after reading from disk to store decrypted data in cache
+    void (*decrypt_callback)(void *decrypt_cookie, void *buffer, size_t count, off_t offset);
+    void *decrypt_cookie;
+
     // Asynchronous writes
 #if USE_PTHREADS
     pthread_t writer_thread;
@@ -111,6 +116,7 @@ struct block_cache {
 };
 
 int block_cache_init(struct block_cache *bc, int fd, off_t end_offset, bool is_soft_end_offset, bool enable_trim, bool verify_writes, bool minimize_writes);
+void block_cache_set_decrypt(struct block_cache *bc, void (*decrypt_callback)(void *, void *, size_t, off_t), void *cookie);
 int block_cache_trim(struct block_cache *bc, off_t offset, off_t count, bool hwtrim);
 int block_cache_trim_after(struct block_cache *bc, off_t offset, bool hwtrim);
 int block_cache_pwrite(struct block_cache *bc, const void *buf, size_t count, off_t offset, bool streamed);

--- a/src/fwup_apply.c
+++ b/src/fwup_apply.c
@@ -255,15 +255,9 @@ static int xdelta_read_source_callback(void *cookie, void *buf, size_t count, of
         offset > fctx->xd_source_count - count)
         count = fctx->xd_source_count - offset;
 
+    // NOTE: Decryption is now handled by block_cache_set_decrypt(), so the cache
+    // contains decrypted data. This eliminates redundant decryption on cache hits.
     int rc = block_cache_pread(fctx->output, buf, count, fctx->xd_source_offset + offset);
-    if (fctx->xd_source_dc && rc > 0) {
-        // Verify xdelta3 offset/count alignment. See fwup_xdelta3.c.
-        if (offset & (FWUP_BLOCK_SIZE - 1) ||
-            count & (FWUP_BLOCK_SIZE - 1))
-            ERR_RETURN("xdelta3 source read not aligned to block size. Please report this bug. offset: %" PRId64 ", count: %zu", offset, count);
-
-        disk_crypto_decrypt(fctx->xd_source_dc, buf, buf, rc, fctx->xd_source_offset + offset);
-    }
 
     return rc;
 }
@@ -299,6 +293,13 @@ static int read_callback(struct fun_context *fctx, const void **buffer, size_t *
         return read_callback_xdelta(fctx, buffer, len, offset);
     else
         return read_callback_normal(fctx, buffer, len, offset);
+}
+
+// Wrapper for disk_crypto_decrypt to match block_cache decrypt callback signature
+static void block_cache_decrypt_wrapper(void *cookie, void *buffer, size_t count, off_t offset)
+{
+    struct disk_crypto *dc = (struct disk_crypto *) cookie;
+    disk_crypto_decrypt(dc, buffer, buffer, count, offset);
 }
 
 static void initialize_timestamps()
@@ -425,6 +426,8 @@ static int run_task(struct fun_context *fctx, struct fwup_apply_data *pd)
                 if (source_raw_options) {
                     fctx->xd_source_dc = malloc(sizeof(struct disk_crypto));
                     OK_OR_CLEANUP(disk_crypto_init(fctx->xd_source_dc, source_raw_offset * FWUP_BLOCK_SIZE, 1, &source_raw_options));
+                    // Set decrypt callback on block cache to decrypt once when loading from disk
+                    block_cache_set_decrypt(fctx->output, block_cache_decrypt_wrapper, fctx->xd_source_dc);
                 }
 
                 fctx->xd = malloc(sizeof(struct xdelta_state));
@@ -455,6 +458,10 @@ static int run_task(struct fun_context *fctx, struct fwup_apply_data *pd)
 
 { // MOVE ME!!!
     if (fctx->xd) {
+        // Clear decrypt callback before freeing crypto context
+        if (fctx->xd_source_dc)
+            block_cache_set_decrypt(fctx->output, NULL, NULL);
+            
         xdelta_free(fctx->xd);
         free(fctx->xd);
         if (fctx->xd_source_dc)


### PR DESCRIPTION
When reading encrypted source data for delta updates, decryption was happening after the block cache returned data. This meant every cache hit still required a decrypt operation, even though the data was already in memory.

This change moves decryption into the cache layer itself. Data is decrypted once when loaded from disk and stored decrypted in the cache. Subsequent hits return the already-decrypted data, eliminating redundant crypto operations.