### PR TITLE
mmc_osx.c: add missing headers

### DIFF
--- a/src/mmc_osx.c
+++ b/src/mmc_osx.c
@@ -22,6 +22,8 @@
 #include <DiskArbitration/DiskArbitration.h>
 #include <IOKit/storage/IOStorageProtocolCharacteristics.h>
 
+#include <fcntl.h>
+#include <unistd.h>
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/stat.h>


### PR DESCRIPTION
Closes: https://github.com/fwup-home/fwup/issues/286