### PR TITLE
Fix 222_block_cache_pread_count always skipping on x86_64 Linux

### DIFF
--- a/tests/222_block_cache_pread_count.test
+++ b/tests/222_block_cache_pread_count.test
@@ -12,8 +12,9 @@ if [ ! -f "$PREAD_SHIM" ]; then
     echo "Skipping: pread shim not available"
     exit 77
 fi
+# Use FWUP_CREATE since FWUP_APPLY may be wrapped in verify-syscalls
 if ! LD_PRELOAD="$PREAD_SHIM" DYLD_INSERT_LIBRARIES="$PREAD_SHIM" \
-        "$FWUP_APPLY" --version >/dev/null 2>&1; then
+        "$FWUP_CREATE" --version >/dev/null 2>&1; then
     echo "Skipping: pread shim injection not functional on this system"
     exit 77
 fi

--- a/tests/fixture/pread_shim.c
+++ b/tests/fixture/pread_shim.c
@@ -40,6 +40,10 @@ __attribute__((constructor)) void pread_shim_init()
 
 __attribute__((destructor)) void pread_shim_fini()
 {
+    // Don't let processes that never opened the image clobber the count
+    if (image_fd < 0)
+        return;
+
     const char *outfile = getenv("PREAD_SHIM_OUTFILE");
     if (outfile) {
         FILE *f = fopen(outfile, "w");


### PR DESCRIPTION
Noticed while working on #293 that this test never actually runs on x86_64 Linux (including CI) — it always reports SKIP. Two stacked issues:

1. **The shim-functional check self-defeats.** It runs `"$FWUP_APPLY" --version`, but on x86_64 Linux `common.sh` wraps `FWUP_APPLY` in the `verify-syscalls` ptrace wrapper, which exits nonzero on `--version` because `fwup.img` is never opened. The check fails and the test skips on exactly the platform it was written for. Fixed by probing against `FWUP_CREATE`, which is never wrapped.

2. **The count file gets clobbered.** With the skip fixed, the test failed with `0 reads` for both runs: the pread shim writes its count from a destructor in every process that loads it. The `verify-syscalls` wrapper inherits `LD_PRELOAD`, never opens the image, and exits after the traced child — overwriting the real count with 0. Fixed by only writing the count from a process that actually opened the image.

With both fixes the test runs and passes on x86_64 Linux.