### PR TITLE
Fix mtools version sensitivity in 095 and 099 FAT tests

### DIFF
--- a/tests/095_sparse_apply.test
+++ b/tests/095_sparse_apply.test
@@ -102,23 +102,9 @@ cmp_bytes 9234631 $SPARSE_FILE $IMGFILE
 rm $IMGFILE
 $FWUP_APPLY -a -d $IMGFILE -i $NEW_FWFILE -t fat
 
-EXPECTED_FAT_OUTPUT=$WORK/expected.out
-ACTUAL_FAT_OUTPUT=$WORK/actual.out
-
-cat >$EXPECTED_FAT_OUTPUT << EOF
- Volume in drive : has no label
- Volume Serial Number is 0021-7FF8
-Directory for ::/
-
-sparse   bin   9234631 1980-01-01   0:00
-        1 file            9 234 631 bytes
-                          7 390 208 bytes free
-
-EOF
-
 # Check that the directory looks right
-mdir -i $WORK/fwup.img > $ACTUAL_FAT_OUTPUT
-diff -w $EXPECTED_FAT_OUTPUT $ACTUAL_FAT_OUTPUT
+mdir -i $WORK/fwup.img > $WORK/actual.out
+grep -qi "^sparse.* 9234631 1980-01-01" $WORK/actual.out
 
 # Check the contents of the file
 mcopy -n -i $WORK/fwup.img ::/sparse.bin $WORK/actual.sparse.bin

--- a/tests/099_sparse_lasthole.test
+++ b/tests/099_sparse_lasthole.test
@@ -69,23 +69,9 @@ cmp_bytes 1536 $SPARSE_FILE $IMGFILE 0 2048
 rm $IMGFILE
 $FWUP_APPLY -a -d $IMGFILE -i $NEW_FWFILE -t fat
 
-EXPECTED_FAT_OUTPUT=$WORK/expected.out
-ACTUAL_FAT_OUTPUT=$WORK/actual.out
-
-cat >$EXPECTED_FAT_OUTPUT << EOF
- Volume in drive : has no label
- Volume Serial Number is 0021-7FF8
-Directory for ::/
-
-sparse   bin      1536 1980-01-01   0:00
-        1 file                1 536 bytes
-                         16 623 616 bytes free
-
-EOF
-
 # Check that the directory looks right
-mdir -i $WORK/fwup.img > $ACTUAL_FAT_OUTPUT
-diff -w $EXPECTED_FAT_OUTPUT $ACTUAL_FAT_OUTPUT
+mdir -i $WORK/fwup.img > $WORK/actual.out
+grep -qi "^sparse.* 1536 1980-01-01" $WORK/actual.out
 
 # Check the contents of the file
 mcopy -n -i $WORK/fwup.img ::/sparse.bin $WORK/actual.sparse.bin


### PR DESCRIPTION
Follow-up to #287. That PR relaxed the exact `mdir` directory-listing comparison in the FAT tests to tolerate newer mtools formatting, but missed `095_sparse_apply` and `099_sparse_lasthole` (the two sparse tests that mkfs at offset 0 and so weren't in the `@@32256` batch).

## The failure

On the macOS CI runners (mtools 4.0.49), `mdir` renders the short-name directory entry with a phantom column for entries that use the VFAT lowercase NT-case flags:

```
< sparse   bin   9234631 ...
> sparse  _bin bin   9234631 ...
```

so the exact `diff` fails. It's nondeterministic — it hits a different subset of the exact-diff FAT tests each run, which is why it only ever showed up on CI.

## Root cause (confirmed, not an fwup bug)

fwup writes a valid entry — verified by dumping the raw root-dir bytes on both Linux and an arm64 Mac:

```
53 50 41 52 53 45 20 20  42 49 4e 20  18   ...
S  P  A  R  S  E  ␠  ␠   B  I  N  ␠   NTflags=0x18
```

Short name `SPARSE␠␠BIN`, byte 0x0C = `0x18` (lowercase basename + ext), no LFN entry, preceding slot zeroed. The `_bin` is purely mtools's rendering of that entry. File content is already independently verified by the existing `mcopy` + `cmp`.

## Fix

Replace the full-listing `diff` with the same targeted `grep` #287 introduced. Reproduced the failure and verified the fix on an arm64 Mac (macOS 26, mtools 4.0.49) via `make distcheck`, and confirmed no regression on Linux.